### PR TITLE
fix: array key variable substitution in export-patches

### DIFF
--- a/nix/commands/export-patches.sh
+++ b/nix/commands/export-patches.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC2124
+# shellcheck disable=SC2086,SC2124,SC2016
 
 set -e
 
@@ -10,7 +10,7 @@ source "$basedir/__load-env.sh"
 function array_key_exists() {
   local _array_name="$1"
   local _key="$2"
-  local _cmd="echo ${!"$_array_name"[@]}"
+  local _cmd='echo ${!'$_array_name'[@]}'
   local _array_keys
   mapfile -t _array_keys < <(eval $_cmd)
 


### PR DESCRIPTION
Fixes a double-quote issue that caused bad variable substitution:

<img width="688" alt="Screen Shot 2019-10-04 at 10 19 35 AM" src="https://user-images.githubusercontent.com/2036040/66192323-7a1e5c80-e690-11e9-9adf-dae2b080eace.png">

cc @ckerr 