### PR TITLE
chore: add support for yaml and extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "prettier --check \"src/*.js\" \"tests/*.js\" \"src/e\"",
     "prettier:write": "prettier --write \"src/*.js\" \"tests/*.js\" \"src/e\"",
-    "test":     "nyc --reporter=lcov --reporter=text-summary jest --config=jest.fast.json",
+    "test": "nyc --reporter=lcov --reporter=text-summary jest --config=jest.fast.json",
     "test:all": "nyc --reporter=lcov --reporter=text-summary jest --config=jest.slow.json"
   },
   "repository": "https://github.com/electron/build-tools",
@@ -18,8 +18,10 @@
     "chalk": "^2.4.1",
     "command-exists": "^1.2.8",
     "commander": "^3.0.2",
+    "lodash": "^4.17.15",
     "open": "^6.4.0",
-    "path-key": "^3.1.0"
+    "path-key": "^3.1.0",
+    "yaml-js": "^0.2.3"
   },
   "devDependencies": {
     "jest": "^24.9.0",

--- a/src/e-test.js
+++ b/src/e-test.js
@@ -39,6 +39,10 @@ function runSpecRunner(config, script, runnerArgs) {
     stdio: 'inherit',
     encoding: 'utf8',
     cwd: path.resolve(config.root, 'src', 'electron'),
+    env: {
+      ELECTRON_OUT_DIR: config.gen.out,
+      ...process.env,
+    },
   };
   console.log(color.childExec(exec, args, opts));
   childProcess.execFileSync(exec, args, opts);

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -7,33 +7,44 @@ const { color, ensureDir } = require('./util');
 
 const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'configs');
 const currentFile = path.resolve(configRoot, 'evm-current.txt');
+const preferredFormat = process.env.EVM_FORMAT || 'json'; // yaml yml json
 
+function buildPath(name, suffix) {
+  return path.resolve(configRoot, `evm.${name}.${suffix}`);
+}
+
+function buildPathCandidates(name) {
+  const suffixes = ['json', 'yml', 'yaml'];
+  return suffixes.map(suffix => buildPath(name, suffix));
+}
+
+// get the existing filename if it exists; otherwise the preferred name
 function pathOf(name) {
-  const jsonPath = path.resolve(configRoot, `evm.${name}.json`);
-  if (fs.existsSync(jsonPath)) {
-    return jsonPath;
-  }
-  return path.resolve(configRoot, `evm.${name}.yml`);
+  const files = buildPathCandidates(name).filter(file => fs.existsSync(file));
+  return files[0] || buildPath(name, preferredFormat);
 }
 
 function filenameToConfigName(filename) {
-  const jsonMatch = filename.match(/^evm\.(.*)\.json$/);
-  if (jsonMatch) return jsonMatch[1];
-  const ymlMatch = filename.match(/^evm\.(.*)\.yml$/);
-  return ymlMatch ? ymlMatch[1] : null;
+  const match = filename.match(/^evm\.(.*)\.(?:json|yml|yaml)$/);
+  return match ? match[1] : null;
 }
 
 function save(name, o) {
   ensureDir(configRoot);
   const filename = pathOf(name);
-  const txt = JSON.stringify(o, null, 2) + '\n';
+  const txt =
+    (path.extname(filename) === '.json' ? JSON.stringify(o, null, 2) : yml.dump(o)) + '\n';
   fs.writeFileSync(filename, txt);
 }
 
 function setCurrent(name) {
   const filename = pathOf(name);
   if (!fs.existsSync(filename)) {
-    throw Error(`Build config ${color.config(name)} not found. (Tried ${color.path(filename)}.)`);
+    throw Error(
+      `Build config ${color.config(name)} not found. (Tried ${buildPathCandidates(name)
+        .map(f => color.path(f))
+        .join(', ')})`,
+    );
   }
   try {
     fs.writeFileSync(currentFile, `${name}\n`);
@@ -88,10 +99,7 @@ function maybeExtendConfig(config) {
 function loadConfigFileRaw(name) {
   const configFile = pathOf(name);
   const configContents = fs.readFileSync(configFile);
-  if (path.extname(configFile) === '.yml') {
-    return maybeExtendConfig(yml.load(configContents));
-  }
-  return maybeExtendConfig(JSON.parse(configContents));
+  return maybeExtendConfig(yml.load(configContents));
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,7 +2258,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.13:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3766,6 +3766,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml-js@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/yaml-js/-/yaml-js-0.2.3.tgz#f4cf6c1b3c784f59f55547d7dfcdd06418303291"
+  integrity sha512-6xUQtVKl1qcd0EXtTEzUDVJy9Ji1fYa47LtkDtYKlIjhibPE9knNPmoRyf6SGREFHlOAUyDe9OdYqRP4DuSi5Q==
 
 yargs-parser@^13.0.0, yargs-parser@^13.1.1:
   version "13.1.1"


### PR DESCRIPTION
This adds support for yaml and a new `extends` attribute in config objects to allow config re-use.

It also fixes a bug in `e test` where `ELECTRON_OUT_DIR` was not set correctly