### PR TITLE
fix: choose serialize format based on file suffix

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -7,33 +7,44 @@ const { color, ensureDir } = require('./util');
 
 const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'configs');
 const currentFile = path.resolve(configRoot, 'evm-current.txt');
+const preferredFormat = process.env.EVM_FORMAT || 'json'; // yaml yml json
 
+function buildPath(name, suffix) {
+  return path.resolve(configRoot, `evm.${name}.${suffix}`);
+}
+
+function buildPathCandidates(name) {
+  const suffixes = ['json', 'yml', 'yaml'];
+  return suffixes.map(suffix => buildPath(name, suffix));
+}
+
+// get the existing filename if it exists; otherwise the preferred name
 function pathOf(name) {
-  const jsonPath = path.resolve(configRoot, `evm.${name}.json`);
-  if (fs.existsSync(jsonPath)) {
-    return jsonPath;
-  }
-  return path.resolve(configRoot, `evm.${name}.yml`);
+  const files = buildPathCandidates(name).filter(file => fs.existsSync(file));
+  return files[0] || buildPath(name, preferredFormat);
 }
 
 function filenameToConfigName(filename) {
-  const jsonMatch = filename.match(/^evm\.(.*)\.json$/);
-  if (jsonMatch) return jsonMatch[1];
-  const ymlMatch = filename.match(/^evm\.(.*)\.yml$/);
-  return ymlMatch ? ymlMatch[1] : null;
+  const match = filename.match(/^evm\.(.*)\.(?:json|yml|yaml)$/);
+  return match ? match[1] : null;
 }
 
 function save(name, o) {
   ensureDir(configRoot);
   const filename = pathOf(name);
-  const txt = JSON.stringify(o, null, 2) + '\n';
+  const txt =
+    (path.extname(filename) === '.json' ? JSON.stringify(o, null, 2) : yml.dump(o)) + '\n';
   fs.writeFileSync(filename, txt);
 }
 
 function setCurrent(name) {
   const filename = pathOf(name);
   if (!fs.existsSync(filename)) {
-    throw Error(`Build config ${color.config(name)} not found. (Tried ${color.path(filename)}.)`);
+    throw Error(
+      `Build config ${color.config(name)} not found. (Tried ${buildPathCandidates(name)
+        .map(f => color.path(f))
+        .join(', ')})`,
+    );
   }
   try {
     fs.writeFileSync(currentFile, `${name}\n`);
@@ -88,10 +99,7 @@ function maybeExtendConfig(config) {
 function loadConfigFileRaw(name) {
   const configFile = pathOf(name);
   const configContents = fs.readFileSync(configFile);
-  if (path.extname(configFile) === '.yml') {
-    return maybeExtendConfig(yml.load(configContents));
-  }
-  return maybeExtendConfig(JSON.parse(configContents));
+  return maybeExtendConfig(yml.load(configContents));
 }
 
 module.exports = {


### PR DESCRIPTION
The yml support is fine and I _love_ the `extends` feature

There are a couple of issues in qol as-is

1. (bug) it unconditionally serializes as json, even though the file returned by pathOf() can be `.yml`. So any new config that you create with `e init` will have a `.yml` suffix but be formatted as json.

2. (wart) The error thrown in `setCurrent()` will only say that it tested the `evm.name.yml` file, implying that other formats were ignored. Ideally that error would show all the files that were tried

3. (wart) Since yaml is a superset of json, the if-else in loadConfigFileRaw() isn't necessary -- everything can be passed through yaml.load

4. It reads but doesn't write yaml, so this half-supported feature is only really good for people hand-crafting their own config files -- iow, for you porting over your existing configs :smiley_cat: This PR both reads and writes, and lets you choose a preferred format via the EVM_FORMAT environment variable (default: json)