### PR TITLE
fix: properly pass extra cli options

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: Lint bash code with shellcheck
+    - name: Lint
       run: |
         npm install
         npm run lint

--- a/src/e
+++ b/src/e
@@ -11,35 +11,43 @@ program.description('Electron build tool').usage('<command> [commandArgs...]');
 program
   .command('init [options] <name>', 'Create a new build config')
   .alias('new')
-  .command('sync [gclientArgs...]', 'Get / update source code')
+  .command('sync [gclientArgs...]', 'Get or update source code')
   .command('build [options]', 'Build Electron and other things')
   .alias('make');
 
 program
-  .command('start [electronArgs...]')
+  .command('start')
   .alias('run')
+  .description('Run the Electron executable')
   .allowUnknownOption()
-  .description('Run the Electron build')
   .action(() => {
     try {
       const exec = evmConfig.execOf(evmConfig.current());
-      const args = program.parseOptions(program.rawArgs.slice(2)).unknown;
+      const args = program.rawArgs.slice(3);
       const opts = { stdio: ['ignore', 'inherit', 'ignore'] };
       console.log(color.childExec(exec, args, opts));
       childProcess.execFileSync(exec, args, opts);
     } catch (e) {
       fatal(e);
     }
+  })
+  .on('--help', () => {
+    console.log('');
+    console.log('Examples:');
+    console.log('');
+    console.log('  $ e start .');
+    console.log('  $ e start /path/to/app');
+    console.log('  $ e start /path/to/app --js-flags');
   });
 
 program
-  .command('node [electronArgs...]')
-  .allowUnknownOption()
+  .command('node')
   .description('Run the Electron build as if it were a Node.js executable')
+  .allowUnknownOption()
   .action(() => {
     try {
       const exec = evmConfig.execOf(evmConfig.current());
-      const args = program.parseOptions(program.rawArgs.slice(2)).unknown;
+      const args = program.rawArgs.slice(3);
       const opts = {
         env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
         stdio: ['ignore', 'inherit', 'ignore'],
@@ -49,6 +57,13 @@ program
     } catch (e) {
       fatal(e);
     }
+  })
+  .on('--help', () => {
+    console.log('');
+    console.log('Examples:');
+    console.log('');
+    console.log('  $ e node .');
+    console.log('  $ e node /path/to/app');
   });
 
 program.command('debug', 'Run the Electron build with a debugger (gdb or lldb)');


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/28.

`.allowUnknownOptions()` allows unknown options to be passed to a command without throwing an error, but with one twist - it only considers options to be those that start with `--`. That means that if we were to run `e start my-electron-app` it would consider `my-electron-app` to be an `arg`, and so with current code would just never be passed to `execFileSync`, since we were assuming all non-specified strings after the command would get pushed into `unknown`.

Also added some help text to both `e node` and `e start`.

cc @MarshallOfSound and @ckerr 