### PR TITLE
chore: use js-yaml instead of yaml-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "chalk": "^2.4.1",
     "command-exists": "^1.2.8",
     "commander": "^3.0.2",
+    "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "open": "^6.4.0",
-    "path-key": "^3.1.0",
-    "yaml-js": "^0.2.3"
+    "path-key": "^3.1.0"
   },
   "devDependencies": {
     "jest": "^24.9.0",

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const yml = require('yaml-js');
+const yml = require('js-yaml');
 const { color, ensureDir } = require('./util');
 
 const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'configs');
@@ -33,7 +33,7 @@ function save(name, o) {
   ensureDir(configRoot);
   const filename = pathOf(name);
   const txt =
-    (path.extname(filename) === '.json' ? JSON.stringify(o, null, 2) : yml.dump(o)) + '\n';
+    (path.extname(filename) === '.json' ? JSON.stringify(o, null, 2) : yml.safeDump(o)) + '\n';
   fs.writeFileSync(filename, txt);
 }
 
@@ -99,7 +99,7 @@ function maybeExtendConfig(config) {
 function loadConfigFileRaw(name) {
   const configFile = pathOf(name);
   const configContents = fs.readFileSync(configFile);
-  return maybeExtendConfig(yml.load(configContents));
+  return maybeExtendConfig(yml.safeLoad(configContents));
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3767,11 +3767,6 @@ yallist@^3.0.0, yallist@^3.0.3:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml-js@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/yaml-js/-/yaml-js-0.2.3.tgz#f4cf6c1b3c784f59f55547d7dfcdd06418303291"
-  integrity sha512-6xUQtVKl1qcd0EXtTEzUDVJy9Ji1fYa47LtkDtYKlIjhibPE9knNPmoRyf6SGREFHlOAUyDe9OdYqRP4DuSi5Q==
-
 yargs-parser@^13.0.0, yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"


### PR DESCRIPTION
We already have to install js-yaml for the nyc-based coverage tests, so this change reduces our dependency list. It's also better maintained and generates prettier output.