### PR TITLE
feat: add build time telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 node_modules
 package-lock.json
 third_party
+metrics-uuid

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
     "open": "^6.4.0",
-    "path-key": "^3.1.0"
+    "path-key": "^3.1.0",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "jest": "^24.9.0",

--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -8,11 +8,10 @@ const open = require('open');
 const program = require('commander');
 
 const evmConfig = require('./evm-config');
-const { fatal } = require('./util');
+const { fatal, readElectronVersion } = require('./util');
 
 function guessPRTarget(config) {
-  const filename = path.resolve(config.root, 'src', 'electron', 'package.json');
-  const version = JSON.parse(fs.readFileSync(filename)).version;
+  const version = readElectronVersion(config);
   if (version.includes('nightly')) {
     return 'master';
   }

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const pathKey = require('path-key');
+const makeUuid = require('uuid/v4');
 
 const defaultDepotPath = path.resolve(__dirname, '..', 'third_party', 'depot_tools');
 const DEPOT_TOOLS_DIR = process.env.DEPOT_TOOLS_DIR || defaultDepotPath;
@@ -125,6 +126,11 @@ function ensureSCCache(config) {
   }
 }
 
+function readElectronVersion(config) {
+  const filename = path.resolve(config.root, 'src', 'electron', 'package.json');
+  return JSON.parse(fs.readFileSync(filename)).version;
+}
+
 const color = {
   cmd: str => `"${chalk.cyan(str)}"`,
   config: str => `${chalk.blueBright(str)}`,
@@ -150,6 +156,21 @@ function fatal(e) {
   process.exit(1);
 }
 
+function getOrCreateUuid() {
+  const id_file = path.resolve(__dirname, '..', 'metrics-uuid');
+  try {
+    return String(fs.readFileSync(id_file));
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      const uuid = makeUuid();
+      fs.writeFileSync(id_file, uuid);
+      return uuid;
+    } else {
+      throw err;
+    }
+  }
+}
+
 // public
 
 module.exports = {
@@ -162,6 +183,8 @@ module.exports = {
   },
   ensureDir,
   fatal,
+  getOrCreateUuid,
+  readElectronVersion,
   resolvePath,
   sccache: {
     ensure: ensureSCCache,


### PR DESCRIPTION
This adds telemetry for elapsed build times. I mostly wanted this so that we can give expected full and incremental build times in the docs and inform a future "recommended dev machine specs" section (as discussed at the Electron Summit '19).

I chose an un-authed database, Firebase, because I didn't want to deal with anything more complicated. If someone abuses my account, no big deal, there are spending limits and the data isn't important. However, if we have anything like this already set up (I remember seeing a Grafana graph at one point?), then it'd be easy to switch out.

I anticipate being able to distinguish between incremental and full builds with some basic clustering.

The machine-specific UUID is included in case we want to collect more information about devs' machines later. I threw in what is easily available from Node's `os` to make rudimentary analysis a bit quicker.

Here is a sample record:
```
{
  build_target: "electron",
  cores: 12,
  elapsed_time_ms: 94448,
  electron_version: "7.1.0",
  ram: 34359738368,
  timestamp: 1573087941782,
  uid: "e83b335b-2c79-4d24-9f21-46393a165321"
}
```

Some people might not want this info recorded for some reason; they can `set EVM_SKIP_TELEMETRY=1` or `export EVM_SKIP_TELEMETRY=1`.