### PR TITLE
fix: evm config destructure in patches

### DIFF
--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -8,7 +8,7 @@ const { color, fatal } = require('./util');
 
 function exportPatches(target) {
   try {
-    const { root } = evmConfig.current().config;
+    const { root } = evmConfig.current();
     const srcdir = path.resolve(root, 'src');
 
     const targets = {


### PR DESCRIPTION
Fixes `e patches <dir>` in the wake of https://github.com/electron/build-tools/pull/24.

`evmConfig.current()` now returns:
```
{
  gen: {
    args: [
      'import("//electron/build/args/testing.gn")',
      'cc_wrapper="/Users/codebytere/Developer/electron-gn/src/electron/external_binaries/sccache"'
    ],
    out: 'Testing'
  },
  root: '/Users/codebytere/Developer/electron-gn',
  origin: {
    electron: 'https://github.com/electron/electron',
    node: 'https://github.com/nodejs/node'
  },
  env: {
    GIT_CACHE_PATH: '/Users/codebytere/.git_cache',
    SCCACHE_BUCKET: 'electronjs-sccache-ci',
    SCCACHE_CACHE_SIZE: '40G',
    SCCACHE_TWO_TIER: true
  }
}
```

which meant that `evmConfig.current().config` was `undefined` and errored.