### PR TITLE
feat: fail gracefully on unknown commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ along to the runner.
 # run all tests
 e test
 
-# Run main process tests in CI mode
-e test --ci --runners=main
+# Run main process tests
+e test --runners=main
 ```
 
 ## Getting Information

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "jest": "^24.9.0",
     "nyc": "^14.1.1",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "rimraf": "^3.0.0"
   }
 }

--- a/src/e
+++ b/src/e
@@ -6,7 +6,19 @@ const program = require('commander');
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./util');
 
-program.description('Electron build tool').usage('<command> [commandArgs...]');
+program
+  .description('Electron build tool')
+  .usage('<command> [commandArgs...]')
+  .action(() => {
+    const command = program.rawArgs.slice(2)[0];
+    const isValid = item => item._name === command || item._alias === command;
+    if (!program.commands.find(item => isValid(item))) {
+      console.log('');
+      console.error(`Unrecognized command ${color.cmd(command)}`);
+      console.log('');
+      program.help();
+    }
+  });
 
 program
   .command('init [options] <name>', 'Create a new build config')


### PR DESCRIPTION
Previously, unknown commands would fail silently; no help text would be output and nothing would happen - this might be confusing to users.

This PR checks commands against a list of valid commands and outputs a help text if an unknown command is run.

Before:
<img width="600" alt="Screen Shot 2019-11-07 at 2 05 55 PM" src="https://user-images.githubusercontent.com/2036040/68431723-b9e0d400-0167-11ea-8c4f-081a71cab837.png">

After:
<img width="610" alt="Screen Shot 2019-11-07 at 2 05 29 PM" src="https://user-images.githubusercontent.com/2036040/68431682-aafa2180-0167-11ea-8e64-c36e96779f1b.png">

cc @MarshallOfSound @ckerr 