### PR TITLE
feat: add a load-macos-sdks command to help initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ After installing build-tools, you can run a new Electron build with this command
 ```sh
 # The 'Hello, World!' of build-tools: get and build `master`
 
+# On macOS if you aren't sure you have the right SDK version you should run
+e load-macos-sdks
+
 e init --root=/path/to/new/electron/directory --bootstrap testing
 ```
 

--- a/src/e
+++ b/src/e
@@ -96,7 +96,11 @@ program
   .command('show <subcommand>', 'Show info about the current build config')
   .command('test [specRunnerArgs...]', `Run Electron's spec runner`)
   .command('pr [options]', 'Open a GitHub URL where you can PR your changes')
-  .command('patches <basename>', 'Refresh the patches in $root/src/electron/patches/$basename');
+  .command('patches <basename>', 'Refresh the patches in $root/src/electron/patches/$basename')
+  .command(
+    'load-macos-sdks',
+    'Loads required versions of the macOS SDK and symlinks them.  This may require sudo',
+  );
 
 program.on('--help', () => {
   console.log(`

--- a/src/e-load-macos-sdks.js
+++ b/src/e-load-macos-sdks.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const { color, macOSSDKs } = require('./util');
+
+if (process.platform !== 'darwin') {
+  console.error('Should only configure macOS SDKs on darwin platform');
+  process.exit(1);
+}
+
+macOSSDKs.ensure();
+
+const SDK_TO_LINK = ['10.13', '10.14', '10.15'];
+
+const xCodeSDKDir = path.resolve(
+  '/Applications',
+  'Xcode.app',
+  'Contents',
+  'Developer',
+  'Platforms',
+  'MacOSX.platform',
+  'Developer',
+  'SDKs',
+);
+if (!fs.existsSync(xCodeSDKDir)) {
+  console.error('Could not find Xcode SDK directory.  Please ensure you have installed Xcode');
+  process.exit(1);
+}
+
+for (const sdk of SDK_TO_LINK) {
+  const sourceSDK = path.resolve(macOSSDKs.path, `MacOSX${sdk}.sdk`);
+  if (!fs.existsSync(sourceSDK)) continue;
+
+  const targetDirectory = path.resolve(xCodeSDKDir, `MacOSX${sdk}.sdk`);
+  if (fs.existsSync(targetDirectory)) continue;
+
+  console.warn(
+    `${color.info} Creating a symbolic link from ${color.path(sourceSDK)} --> ${color.path(
+      targetDirectory,
+    )}`,
+  );
+
+  childProcess.execFileSync('sudo', ['ln', '-s', sourceSDK, targetDirectory]);
+}
+
+const output = childProcess.execFileSync('xcode-select', ['-p']).toString();
+if (!output.trim().includes('Xcode.app')) {
+  console.warn(
+    `${color.warn} Looks like your Xcode is not configured correctly, running a command to fix it now`,
+  );
+  console.info(`Setting your Xcode installation to ${color.path('/Applications/Xcode.app')}`);
+  childProcess.execFileSync('sudo', ['xcode-select', '-s', '/Applications/Xcode.app']);
+}
+
+console.log(color.done);

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,7 @@ const path = require('path');
 const pathKey = require('path-key');
 
 const defaultDepotPath = path.resolve(__dirname, '..', 'third_party', 'depot_tools');
+const macOSSDKsPath = path.resolve(__dirname, '..', 'third_party', 'macOS_SDKs');
 const DEPOT_TOOLS_DIR = process.env.DEPOT_TOOLS_DIR || defaultDepotPath;
 
 function resolvePath(p) {
@@ -51,6 +52,16 @@ function ensureDepotTools() {
   if (days_untouched >= days_before_pull) {
     updateDepotTools();
     fs.utimesSync(depot_dir, now, now);
+  }
+}
+
+function ensureMacOSSDKs() {
+  if (!fs.existsSync(macOSSDKsPath)) {
+    console.log(`Cloning ${color.cmd('MacOSX-SDKs')} into ${color.path(macOSSDKsPath)}`);
+    const url = 'https://github.com/phracker/MacOSX-SDKs.git';
+    childProcess.execFileSync('git', ['clone', '-q', url, macOSSDKsPath], { stdio: 'inherit' });
+  } else {
+    childProcess.execFileSync('git', ['pull', '-q'], { cwd: macOSSDKsPath, stdio: 'inherit' });
   }
 }
 
@@ -159,6 +170,10 @@ module.exports = {
     ensure: ensureDepotTools,
     execFileSync: depotExecFileSync,
     execSync: depotExecSync,
+  },
+  macOSSDKs: {
+    path: macOSSDKsPath,
+    ensure: ensureMacOSSDKs,
   },
   ensureDir,
   fatal,


### PR DESCRIPTION
Not sure if we should run this automatically or not, it makes a few assumptions and advanced users may not meet those assumptions.

This will auto-link older macOS SDKs so that we don't have to mess around with Xcode versions on new set ups.