### PR TITLE
fix: revert 98b4ba7 due to unexpected side effects

### DIFF
--- a/src/e
+++ b/src/e
@@ -6,19 +6,7 @@ const program = require('commander');
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./util');
 
-program
-  .description('Electron build tool')
-  .usage('<command> [commandArgs...]')
-  .action(() => {
-    const command = program.rawArgs.slice(2)[0];
-    const isValid = item => item._name === command || item._alias === command;
-    if (!program.commands.find(item => isValid(item))) {
-      console.log('');
-      console.error(`Unrecognized command ${color.cmd(command)}`);
-      console.log('');
-      program.help();
-    }
-  });
+program.description('Electron build tool').usage('<command> [commandArgs...]');
 
 program
   .command('init [options] <name>', 'Create a new build config')


### PR DESCRIPTION
This commit broke some command parsing, e.g. "e show current" and "e show --help" did not work with this fix.

NB: even though this was @codebytere's commit, the bug introduced here is probably [mine](https://github.com/electron/build-tools/pull/34#issuecomment-555123136)... :roll_eyes: 

Also, this is a manual revert rather than a straight `git revert` because that commit also included some changes that we need to keep wrt bumping prettify.

CC @codebytere 