### PR TITLE
docs: show how to add `e` to a win powershell path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@ git clone https://github.com/electron/build-tools.git
 cd build-tools
 yarn install
 
-# then, on Darwin / Linux:
+# then, if on Darwin / Linux:
 export PATH="$PATH:$PWD/src"
 # You should probably add this to your `~/.profile` too:
 export PATH="$PATH:/path/to/build-tools/src"
 
-# then, on Windows:
+# then, if in Windows' cmd:
 cd src
 set PATH=%CD%;%PATH%
+
+# then, if in Windows' PowerShell:
+cd src
+$Env:Path += ";$(pwd)"
 ```
 
 ## Getting the Code and Building Electron


### PR DESCRIPTION
The instructions for adding the `build-tools/src` directory to a user's path works on Windows if using cmd, but not if using PowerShell. This PR updates the README to show how to do it on both.