### PR TITLE
fix: avoid stop-server/start-server race on sccache startup

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -118,17 +118,11 @@ function ensureSCCache(config) {
     return;
   }
 
-  try {
-    childProcess.execFileSync(sccache, ['--stop-server'], opts);
-  } catch {
-    // it's OK for this to fail -- maybe it wasn't running
-  }
-
   for (;;) {
     try {
-      const args = ['--start-server'];
-      console.log(color.childExec(sccache, args, opts));
-      childProcess.execFileSync(sccache, args, opts);
+      console.log(color.childExec(sccache, [], opts));
+      // --show-stats will start the server if not already started.
+      childProcess.execFileSync(sccache, ['--show-stats'], opts);
       break;
     } catch {
       console.warn('Failed to start sccache. Trying again...');


### PR DESCRIPTION
This seems to fix the issue I was seeing where sccache would fail to start 3-5 times before finally succeeding. My guess is that there was a race between when we stopped the server and when we started. This theory was further validated by running `./external_binaries/sccache --stop-server && (ps -ef | grep sccache)` and noting that the process wasn't quite dead by the time `ps` ran. It makes sense; the command requests that the daemon shuts down and returns with no synchronous guarantee.

Instead of stopping and starting the server, we can lean on sccache to ensure the server is started by using `--show-stats`, which [connects or starts the server on its own](https://github.com/mozilla/sccache/blob/dc6845963af96de3521e60921d2718b99c725d9c/src/commands.rs#L548).

I know @codebytere was seeing this problem, too — not sure about everyone else.