### PR TITLE
fix: keep GIT_CACHE_PATH regardless of Goma

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -47,9 +47,6 @@ function createConfig(options) {
   const sccacheEnv = {
     SCCACHE_BUCKET: process.env.SCCACHE_BUCKET || 'electronjs-sccache-ci',
     SCCACHE_CACHE_SIZE: process.env.SCCACHE_CACHE_SIZE || '20G',
-    GIT_CACHE_PATH: process.env.GIT_CACHE_PATH
-      ? resolvePath(process.env.GIT_CACHE_PATH)
-      : path.resolve(homedir, '.git_cache'),
     SCCACHE_DIR: process.env.SCCACHE_DIR
       ? resolvePath(process.env.SCCACHE_DIR)
       : path.resolve(homedir, '.sccache'),
@@ -73,6 +70,9 @@ function createConfig(options) {
     },
     env: {
       CHROMIUM_BUILDTOOLS_PATH: path.resolve(root, 'src', 'buildtools'),
+      GIT_CACHE_PATH: process.env.GIT_CACHE_PATH
+        ? resolvePath(process.env.GIT_CACHE_PATH)
+        : path.resolve(homedir, '.git_cache'),
       ...platform_env,
       ...(!options.useGoma && sccacheEnv),
     },


### PR DESCRIPTION
`GIT_CACHE_PATH` is treated as an sccache-only variable, causing it to be omitted if Goma is in use. I _think_ this is in error, since `GIT_CACHE_PATH` is used by gclient sync rather than by the build?

@codebytere is this correct?