### PR TITLE
chore: set j values when in goma build

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -35,6 +35,9 @@ function runNinja(config, target, ninjaArgs) {
         goma.ensure(config.root);
       }
     }
+    if (!ninjaArgs.includes('-j') && !ninjaArgs.find(arg => /^-j[0-9]+$/.test(arg.trim()))) {
+      ninjaArgs.push('-j', process.platform === 'darwin' ? 50 : 200);
+    }
   } else {
     sccache.ensure(config);
   }


### PR DESCRIPTION
This makes it so if you don't provide a `-j` value and goma is enabled we provide one for you that matches our cluster recommendations. 