### PR TITLE
fix: set the `--use-goma` default value to false

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -141,7 +141,11 @@ program
   .option('--msan', `When building, enable clang's memory sanitizer`, false)
   .option('--lsan', `When building, enable clang's leak sanitizer`, false)
   .option('--bootstrap', 'Run `e sync` and `e build` after creating the build config.')
-  .option('--use-goma', `Use Electron's custom deployment of Goma (only available to maintainers).`, false)
+  .option(
+    '--use-goma',
+    `Use Electron's custom deployment of Goma (only available to maintainers).`,
+    false,
+  )
   .option(
     '--use-https',
     'During `e sync`, set remote origins with https://github... URLs instead of git@github...',

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -23,6 +23,7 @@ function createConfig(options) {
   // build the `gn gen` args
   const gn_args = [`import("//electron/build/args/${options.import}.gn")`];
 
+  console.log(options);
   if (options.useGoma) {
     if (goma.exists(root)) {
       gn_args.push('import("//electron/build/args/goma.gn")');
@@ -140,7 +141,7 @@ program
   .option('--msan', `When building, enable clang's memory sanitizer`, false)
   .option('--lsan', `When building, enable clang's leak sanitizer`, false)
   .option('--bootstrap', 'Run `e sync` and `e build` after creating the build config.')
-  .option('--use-goma', `Use Electron's custom deployment of Goma (only available to maintainers).`)
+  .option('--use-goma', `Use Electron's custom deployment of Goma (only available to maintainers).`, false)
   .option(
     '--use-https',
     'During `e sync`, set remote origins with https://github... URLs instead of git@github...',

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -23,7 +23,6 @@ function createConfig(options) {
   // build the `gn gen` args
   const gn_args = [`import("//electron/build/args/${options.import}.gn")`];
 
-  console.log(options);
   if (options.useGoma) {
     if (goma.exists(root)) {
       gn_args.push('import("//electron/build/args/goma.gn")');


### PR DESCRIPTION
Previously was `undefined`, which caused `e init` to die when dumping config to yaml:

```sh
$ e init --root=/tmp/foo foo
Creating /tmp/foo
Running "python /home/charles/electron/build-tools/third_party/depot_tools/gclient.py config --name src/electron --unmanaged https://github.com/electron/electron" in /tmp/foo
ERROR YAMLException: unacceptable kind of an object to dump [object Undefined]
    at writeNode (/home/charles/electron/build-tools/node_modules/js-yaml/lib/js-yaml/dumper.js:756:13)
    at writeBlockMapping (/home/charles/electron/build-tools/node_modules/js-yaml/lib/js-yaml/dumper.js:634:10)
    at writeNode (/home/charles/electron/build-tools/node_modules/js-yaml/lib/js-yaml/dumper.js:727:9)
    at dump (/home/charles/electron/build-tools/node_modules/js-yaml/lib/js-yaml/dumper.js:817:7)
    at Object.safeDump (/home/charles/electron/build-tools/node_modules/js-yaml/lib/js-yaml/dumper.js:823:10)
    at Object.save (/home/charles/electron/build-tools/src/evm-config.js:36:76)
    at Object.<anonymous> (/home/charles/electron/build-tools/src/e-init.js:171:13)
    at Module._compile (internal/modules/cjs/loader.js:1128:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:983:32)
```