### PR TITLE
feat: add unknown command handler to run depot_tools cmds

### DIFF
--- a/src/e
+++ b/src/e
@@ -5,6 +5,8 @@ const program = require('commander');
 
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
+const depot = require('./utils/depot-tools');
+const goma = require('./utils/goma');
 
 program.description('Electron build tool').usage('<command> [commandArgs...]');
 
@@ -50,7 +52,7 @@ program
       const args = program.rawArgs.slice(3);
       const opts = {
         env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
-        stdio: ['ignore', 'inherit', 'inherit'],
+        stdio: 'inherit',
       };
       console.log(color.childExec(exec, args, opts));
       childProcess.execFileSync(exec, args, opts);
@@ -89,6 +91,32 @@ program
     'load-xcode',
     'Loads required versions of Xcode and the macOS SDK and symlinks them.  This may require sudo',
   );
+
+program
+  .command('depot-tools')
+  .alias('d')
+  .description('Run a command from the depot-tools directory with the correct configuration')
+  .allowUnknownOption()
+  .action(() => {
+    const args = process.argv.slice(3);
+    let cwd;
+    if (args[0] === 'goma_ctl' || args[1] === 'goma_auth') {
+      cwd = goma.dir(evmConfig.current().root);
+      args[0] = `${args[0]}.py`;
+      args.unshift('python');
+    }
+
+    const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {
+      cwd,
+      stdio: 'inherit',
+    });
+    if (status !== 0) {
+      console.error(
+        `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
+      );
+    }
+    process.exit(status);
+  });
 
 program.on('--help', () => {
   console.log(`

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -71,6 +71,12 @@ function depotExecSync(config, cmd, opts_in) {
   childProcess.execSync(cmd, opts);
 }
 
+function depotSpawnSync(config, cmd, args, opts_in) {
+  const opts = depotOpts(config, opts_in);
+  console.log(color.childExec(cmd, args, opts));
+  return childProcess.spawnSync(cmd, args, opts);
+}
+
 function depotExecFileSync(config, exec, args, opts_in) {
   if (exec === 'python' && !path.isAbsolute(args[0])) {
     args[0] = path.resolve(DEPOT_TOOLS_DIR, args[0]);
@@ -85,4 +91,5 @@ module.exports = {
   ensure: ensureDepotTools,
   execFileSync: depotExecFileSync,
   execSync: depotExecSync,
-}
+  spawnSync: depotSpawnSync,
+};

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -1,7 +1,7 @@
 const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { color } = require('./logging')
+const { color } = require('./logging');
 
 const getExternalBinaries = root => path.resolve(root, 'src', 'electron', 'external_binaries');
 const gomaDirExists = root => fs.existsSync(path.resolve(getExternalBinaries(root), 'goma'));
@@ -49,4 +49,5 @@ module.exports = {
   auth: authenticateGoma,
   ensure: ensureGomaStart,
   exists: gomaDirExists,
-}
+  dir: root => path.resolve(getExternalBinaries(root), 'goma'),
+};

--- a/src/utils/macos-sdks.js
+++ b/src/utils/macos-sdks.js
@@ -18,4 +18,4 @@ function ensureMacOSSDKs() {
 module.exports = {
   path: macOSSDKsPath,
   ensure: ensureMacOSSDKs,
-}
+};

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { color} = require('./logging')
+const { color } = require('./logging');
 
 function resolvePath(p) {
   if (path.isAbsolute(p)) return p;
@@ -19,5 +19,5 @@ function ensureDir(dir) {
 
 module.exports = {
   resolvePath,
-  ensureDir
-}
+  ensureDir,
+};

--- a/src/utils/sccache.js
+++ b/src/utils/sccache.js
@@ -2,7 +2,7 @@ const childProcess = require('child_process');
 const os = require('os');
 const path = require('path');
 
-const { color } = require('./logging')
+const { color } = require('./logging');
 
 const getExternalBinaries = root => path.resolve(root, 'src', 'electron', 'external_binaries');
 
@@ -39,4 +39,4 @@ function ensureSCCache(config) {
 module.exports = {
   ensure: ensureSCCache,
   exec: root => getSCCacheExec(root),
-}
+};

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -48,15 +48,15 @@ function ensureXcode() {
   }
 }
 
-function hashFile(file) {	
-  console.log(`Calculating hash for ${color.path(file)}`);	
-  return childProcess	
-    .spawnSync(process.execPath, [path.resolve(__dirname, 'hash.js'), file])	
-    .stdout.toString()	
-    .trim();	
+function hashFile(file) {
+  console.log(`Calculating hash for ${color.path(file)}`);
+  return childProcess
+    .spawnSync(process.execPath, [path.resolve(__dirname, 'hash.js'), file])
+    .stdout.toString()
+    .trim();
 }
 
 module.exports = {
   XcodePath,
   ensureXcode,
-}
+};


### PR DESCRIPTION
Sometimes you want to be able to run `depot_tools` like `gn` manually, this lets you do it.

It's as easy as

```bash
e gn gen
# or
e goma_ctl status
```