### PR TITLE
fix: ignore stdio for the unzip command to prevent ENOBUFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "chalk": "^2.4.1",
     "command-exists": "^1.2.8",
     "commander": "^3.0.2",
-    "cross-zip": "^2.1.6",
     "got": "^10.2.2",
     "hasha": "^5.1.0",
     "js-yaml": "^3.13.1",

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -2,7 +2,6 @@ const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
-const zip = require('cross-zip');
 const { ensureDir } = require('./paths');
 
 const XcodeDir = path.resolve(__dirname, '..', 'third_party', 'Xcode');
@@ -40,7 +39,9 @@ function ensureXcode() {
 
     const unzipPath = path.resolve(XcodeDir, 'tmp_unzip');
     rimraf.sync(unzipPath);
-    zip.unzipSync(XcodeZip, unzipPath);
+    childProcess.spawnSync('unzip', ['-o', XcodeZip, '-d', unzipPath, '-q'], {
+      stdio: 'ignore'
+    });
 
     fs.renameSync(path.resolve(unzipPath, 'Xcode.app'), XcodePath);
     rimraf.sync(XcodeZip);

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,13 +926,6 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-zip@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/cross-zip/-/cross-zip-2.1.6.tgz#344d3ba9488609942987d815bb84860cff3d9491"
-  integrity sha512-xLIETNkzRcU6jGRzenJyRFxahbtP4628xEKMTI/Ql0Vu8m4h8M7uRLVi7E5OYHuJ6VQPsG4icJumKAFUvfm0+A==
-  dependencies:
-    rimraf "^3.0.0"
-
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"


### PR DESCRIPTION
Quite a few people have been seeing `ENOBUFS` while unzipping Xcode, this fixes that by completely ignoring `stdout` for the unzip command.