### PR TITLE
feat: let users of `e pr` specify a target repo

### DIFF
--- a/src/e
+++ b/src/e
@@ -5,6 +5,8 @@ const program = require('commander');
 
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
+const depot = require('./utils/depot-tools');
+const goma = require('./utils/goma');
 
 program.description('Electron build tool').usage('<command> [commandArgs...]');
 
@@ -95,4 +97,28 @@ program.on('--help', () => {
 See https://github.com/electron/build-tools/blob/master/README.md for usage.`);
 });
 
-program.parse(process.argv);
+const result = program.parse(process.argv);
+if (result) {
+  // If we get to here, we ran an unknown command
+  const { rawArgs } = result;
+  const args = rawArgs.slice(2);
+  // Map goma_ctl and goma_auth to our goma client, not depot_tools
+  let cwd;
+  if (args[0] === 'goma_ctl' || args[1] === 'goma_auth') {
+    cwd = goma.dir(evmConfig.current().root);
+    args[0] = `${args[0]}.py`;
+    args.unshift('python');
+  }
+
+  console.log(`${color.info} Treating unknown command as depot tools executable`);
+  const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {
+    cwd,
+    stdio: 'inherit',
+  });
+  if (status !== 0) {
+    console.error(
+      `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
+    );
+  }
+  process.exit(status);
+}

--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -38,10 +38,25 @@ function guessPRSource(config) {
   return childProcess.execSync(command, options).trim();
 }
 
-let defaultTarget;
+function guessRepo(config) {
+  const fallback = 'electron/electron';
+  const origin = config.origin.electron;
+  let repo;
+  if (origin.endsWith('.git')) {
+    let tmp = origin.slice(0, -4);
+    tmp = tmp.replace('https://github.com/', '');
+    tmp = tmp.replace('git@github.com:', '');
+    repo = tmp;
+  }
+  return repo || falback;
+}
+
+let defaultRepo;
 let defaultSource;
+let defaultTarget;
 try {
   const config = evmConfig.current();
+  defaultRepo = guessRepo(config);
   defaultSource = guessPRSource(config);
   defaultTarget = guessPRTarget(config);
 } catch {
@@ -50,8 +65,9 @@ try {
 
 program
   .description('Open a GitHub URL where you can PR your changes')
+  .option('-r, --repo <repository>', 'Repository to use', defaultRepo)
   .option('-s, --source <source_branch>', 'Where the changes are coming from', defaultSource)
   .option('-t, --target <target_branch>', 'Where the changes are going to', defaultTarget)
   .parse(process.argv);
 
-open(`https://github.com/electron/electron/compare/${program.target}...${program.source}?expand=1`);
+open(`https://github.com/${program.repo}/compare/${program.target}...${program.source}?expand=1`);

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -71,6 +71,12 @@ function depotExecSync(config, cmd, opts_in) {
   childProcess.execSync(cmd, opts);
 }
 
+function depotSpawnSync(config, cmd, args, opts_in) {
+  const opts = depotOpts(config, opts_in);
+  console.log(color.childExec(cmd, args, opts));
+  return childProcess.spawnSync(cmd, args, opts);
+}
+
 function depotExecFileSync(config, exec, args, opts_in) {
   if (exec === 'python' && !path.isAbsolute(args[0])) {
     args[0] = path.resolve(DEPOT_TOOLS_DIR, args[0]);
@@ -85,4 +91,5 @@ module.exports = {
   ensure: ensureDepotTools,
   execFileSync: depotExecFileSync,
   execSync: depotExecSync,
-}
+  spawnSync: depotSpawnSync,
+};

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -1,7 +1,7 @@
 const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { color } = require('./logging')
+const { color } = require('./logging');
 
 const getExternalBinaries = root => path.resolve(root, 'src', 'electron', 'external_binaries');
 const gomaDirExists = root => fs.existsSync(path.resolve(getExternalBinaries(root), 'goma'));
@@ -49,4 +49,5 @@ module.exports = {
   auth: authenticateGoma,
   ensure: ensureGomaStart,
   exists: gomaDirExists,
-}
+  dir: root => path.resolve(getExternalBinaries(root), 'goma'),
+};

--- a/src/utils/macos-sdks.js
+++ b/src/utils/macos-sdks.js
@@ -18,4 +18,4 @@ function ensureMacOSSDKs() {
 module.exports = {
   path: macOSSDKsPath,
   ensure: ensureMacOSSDKs,
-}
+};

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { color} = require('./logging')
+const { color } = require('./logging');
 
 function resolvePath(p) {
   if (path.isAbsolute(p)) return p;
@@ -19,5 +19,5 @@ function ensureDir(dir) {
 
 module.exports = {
   resolvePath,
-  ensureDir
-}
+  ensureDir,
+};

--- a/src/utils/sccache.js
+++ b/src/utils/sccache.js
@@ -2,7 +2,7 @@ const childProcess = require('child_process');
 const os = require('os');
 const path = require('path');
 
-const { color } = require('./logging')
+const { color } = require('./logging');
 
 const getExternalBinaries = root => path.resolve(root, 'src', 'electron', 'external_binaries');
 
@@ -39,4 +39,4 @@ function ensureSCCache(config) {
 module.exports = {
   ensure: ensureSCCache,
   exec: root => getSCCacheExec(root),
-}
+};

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -48,15 +48,15 @@ function ensureXcode() {
   }
 }
 
-function hashFile(file) {	
-  console.log(`Calculating hash for ${color.path(file)}`);	
-  return childProcess	
-    .spawnSync(process.execPath, [path.resolve(__dirname, 'hash.js'), file])	
-    .stdout.toString()	
-    .trim();	
+function hashFile(file) {
+  console.log(`Calculating hash for ${color.path(file)}`);
+  return childProcess
+    .spawnSync(process.execPath, [path.resolve(__dirname, 'hash.js'), file])
+    .stdout.toString()
+    .trim();
 }
 
 module.exports = {
   XcodePath,
   ensureXcode,
-}
+};


### PR DESCRIPTION
This lets users specify another repository to use. The default comes from the build-tools config file's `origin.electron`, i.e. `electron/electron`.
    
**IMPORTANT:** While this PR is probably worthwhile on its own, it is NOT a full fix for the issues raised at the training session:

  1. the user has to know to use the `--repo` argument
  2. it doesn't add a new config setting for the repo
  2. it doesn't address url rewriting at all

TBH this here mostly because I mentioned at the training session that I had this change in progress and didn't want anyone to think they needed to block on it. I'm going to be working on my presentation tonight and won't be around to work on build-tools :neutral_face: 