### PR TITLE
feat: let users of 'e pr' specify a target repo

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -38,10 +38,25 @@ function guessPRSource(config) {
   return childProcess.execSync(command, options).trim();
 }
 
-let defaultTarget;
+function guessRepo(config) {
+  const fallback = 'electron/electron';
+  const origin = config.origin.electron;
+  let repo;
+  if (origin.endsWith('.git')) {
+    let tmp = origin.slice(0, -4);
+    tmp = tmp.replace('https://github.com/', '');
+    tmp = tmp.replace('git@github.com:', '');
+    repo = tmp;
+  }
+  return repo || falback;
+}
+
+let defaultRepo;
 let defaultSource;
+let defaultTarget;
 try {
   const config = evmConfig.current();
+  defaultRepo = guessRepo(config);
   defaultSource = guessPRSource(config);
   defaultTarget = guessPRTarget(config);
 } catch {
@@ -50,8 +65,9 @@ try {
 
 program
   .description('Open a GitHub URL where you can PR your changes')
+  .option('-r, --repo <repository>', 'Repository to use', defaultRepo)
   .option('-s, --source <source_branch>', 'Where the changes are coming from', defaultSource)
   .option('-t, --target <target_branch>', 'Where the changes are going to', defaultTarget)
   .parse(process.argv);
 
-open(`https://github.com/electron/electron/compare/${program.target}...${program.source}?expand=1`);
+open(`https://github.com/${program.repo}/compare/${program.target}...${program.source}?expand=1`);


### PR DESCRIPTION
This lets users specify another repository to use. The default comes from the build-tools config file's `origin.electron`, i.e. `electron/electron`.
    
**IMPORTANT:** While this PR is probably worthwhile on its own, it is NOT a full fix for the issues raised at the training session:

  1. the user has to know to use the `--repo` argument
  2. it doesn't add a new config setting for the repo
  2. it doesn't address url rewriting at all

TBH this here mostly because I mentioned at the training session that I had this change in progress and didn't want anyone to think they needed to block on it. I'm going to be working on my presentation tonight and won't be around to work on build-tools :neutral_face: 