### PR TITLE
fix: race condition with external binary download

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -184,12 +184,16 @@ try {
   const opts = { stdio: 'inherit' };
   childProcess.execFileSync('node', [e, 'use', name], opts);
 
+  // (maybe) run sync to ensure external binaries are downloaded
+  if (program.bootstrap) {
+    childProcess.execFileSync('node', [e, 'sync', '-v'], opts);
+  }
+
   // maybe authenticate with Goma
   if (config.goma) goma.auth(config.root);
 
-  // maybe bootstrap
+  // (maybe) build Electron
   if (program.bootstrap) {
-    childProcess.execFileSync('node', [e, 'sync', '-v'], opts);
     childProcess.execFileSync('node', [e, 'build'], opts);
   }
 } catch (e) {


### PR DESCRIPTION
Fix a race condition whereby the external binaries won't have finished downloading by the time we run build, so goma auth would not work properly.

cc @MarshallOfSound 