### PR TITLE
fix: e start --inherit not working

### DIFF
--- a/src/e
+++ b/src/e
@@ -26,7 +26,7 @@ program
     try {
       const exec = evmConfig.execOf(evmConfig.current());
       const args = program.rawArgs.slice(3);
-      const opts = { stdio: ['ignore', 'inherit', 'inherit'] };
+      const opts = { stdio: 'inherit' };
       console.log(color.childExec(exec, args, opts));
       childProcess.execFileSync(exec, args, opts);
     } catch (e) {


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/56.

We were setting `stdio: ['ignore', 'inherit', 'inherit']` and should just have been passing `stdio: 'inherit'`

cc @ckerr @MarshallOfSound 