### PR TITLE
feat: add file tab completion to 'e start' on zsh

### DIFF
--- a/tools/zsh/_e
+++ b/tools/zsh/_e
@@ -96,6 +96,13 @@ case $line[1] in
     && ret=0
   ;;
 
+  # in 'e start' / 'e node',
+  # try file completion on remaining args
+  (start|run|node)
+    _path_files \
+    && ret=0
+  ;;
+
   (*)
     __e_get_cmd_subcommands e $line[1]
     __e_get_cmd_options e $line[1]


### PR DESCRIPTION
When typing a partial filename after `e run`, use zsh's file completion to try and match it. For example `e run m<tab>'` might try to match `e run main.js`

Works for both 'start'/'run' and for 'node'