### PR TITLE
feat: add support for custom binaryName

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -74,14 +74,16 @@ function outDir(config) {
 }
 
 function execOf(config) {
+  const execName = (config.execName || 'electron').toLowerCase();
   const builddir = outDir(config);
   switch (os.type()) {
     case 'Linux':
-      return path.resolve(builddir, 'electron');
+      return path.resolve(builddir, execName);
     case 'Darwin':
-      return path.resolve(builddir, 'Electron.app', 'Contents', 'MacOS', 'Electron');
+      const upperExecName = execName[0].toUpperCase() + execName.slice(1);
+      return path.resolve(builddir, `${upperExecName}.app`, 'Contents', 'MacOS', upperExecName);
     default:
-      return path.resolve(builddir, 'electron.exe');
+      return path.resolve(builddir, `${execName}.exe`);
   }
 }
 


### PR DESCRIPTION
This is helpful for building other projects with build tools like `Chromium`.  I can get the full build flow working with this config now.

```yaml
goma: cluster
root: /Users/sattard/projects/chromium
binaryName: chromium
gen:
  args:
    - is_debug = false
    - import("/Users/{user}/projects/electron/build-tools/third_party/goma.gn")
  out: Testing
env:
  CHROMIUM_BUILDTOOLS_PATH: /Users/sattard/projects/chromium/src/buildtools
  GIT_CACHE_PATH: /Users/sattard/.git_cache
```
