### PR TITLE
feat: add support for EVM_SESSION_ID to have per-shell config selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,16 @@ Valid patch directories include:
 [nvm]: https://github.com/nvm-sh/nvm
 [platform-prerequisites]: https://electronjs.org/docs/development/build-instructions-gn#platform-prerequisites
 [sanitizers]: https://github.com/google/sanitizers
+
+## Advanced Usage
+
+### Per-Session Active Configs
+
+If you want your shell sessions to each have different active configs, try this in your `~/.profile` or `~/.zshrc` or `~/.bashrc`:
+
+```sh
+export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+```
+
+This will create per-shell temporary files in which he active config file can be changed with `e use`.
+

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -7,13 +7,16 @@ const { color } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const goma = require('./utils/goma');
 
-const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'configs');
-const currentFile = path.resolve(configRoot, 'evm-current.txt');
-let sessionFile;
-if (process.env.EVM_SESSION_ID && !process.env.EVM_SESSION_ID.includes('.')) {
-  sessionFile = path.resolve(configRoot, 'sessions', process.env.EVM_SESSION_ID, 'evm-current.txt');
-}
 const preferredFormat = process.env.EVM_FORMAT || 'json'; // yaml yml json
+const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'configs');
+
+// If you want your shell sessions to each have different active configs,
+// try this in your ~/.profile or ~/.zshrc or ~/.bashrc:
+// export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+const currentFiles = _.compact([
+  process.env.EVM_CURRENT_FILE,
+  path.resolve(configRoot, 'evm-current.txt'),
+]);
 
 function buildPath(name, suffix) {
   return path.resolve(configRoot, `evm.${name}.${suffix}`);
@@ -44,8 +47,7 @@ function save(name, o) {
 }
 
 function setCurrent(name) {
-  const filename = pathOf(name);
-  if (!fs.existsSync(filename)) {
+  if (!fs.existsSync(pathOf(name))) {
     throw Error(
       `Build config ${color.config(name)} not found. (Tried ${buildPathCandidates(name)
         .map(f => color.path(f))
@@ -53,12 +55,7 @@ function setCurrent(name) {
     );
   }
   try {
-    fs.mkdirSync(path.dirname(currentFile), { recursive: true });
-    fs.writeFileSync(currentFile, `${name}\n`);
-    if (sessionFile) {
-      fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-      fs.writeFileSync(sessionFile, `${name}\n`);
-    }
+    currentFiles.forEach(filename => fs.writeFileSync(filename, `${name}\n`));
   } catch (e) {
     throw Error(`Unable to set evm config ${color.config(name)} (${e})`);
   }
@@ -73,15 +70,18 @@ function names() {
 }
 
 function currentName() {
-  if (process.env.EVM_CURRENT) return process.env.EVM_CURRENT;
-  if (sessionFile && fs.existsSync(sessionFile))
-    return fs.readFileSync(sessionFile, { encoding: 'utf8' }).trim();
-
-  if (!fs.existsSync(currentFile)) throw Error('No current build configuration');
-  const current = fs.readFileSync(currentFile, { encoding: 'utf8' }).trim();
-  // If we fell back to the "current" file then we should set the sessionFile for future usage
-  if (sessionFile) setCurrent(current);
-  return current;
+  // return the contents of the first nonempty file in currentFiles
+  const name = currentFiles.reduce((name, filename) => {
+    try {
+      return name || fs.readFileSync(filename, { encoding: 'utf8' }).trim();
+    } catch (e) {
+      return;
+    }
+  }, null);
+  if (name) {
+    return name;
+  }
+  throw Error('No current build configuration');
 }
 
 function outDir(config) {


### PR DESCRIPTION
Fixes #72 

By adding `export EVM_SESSION_ID=$(uuid)` to your `.bashrc` or `.zshrc` file you can get per-session evm configs, so you can use different configs in different shells.

`e use X` will set both your session and the global config to `X`
`e <anything>` will attempt to read your session, if it fails it will read global and then instantly set that result to your session