### PR TITLE
refactor: use EVM_CURRENT_FILE to avoid fs clutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,9 @@ Valid patch directories include:
 [platform-prerequisites]: https://electronjs.org/docs/development/build-instructions-gn#platform-prerequisites
 [sanitizers]: https://github.com/google/sanitizers
 
-## Per-Session Active Configs
+## Advanced Usage
+
+### Per-Session Active Configs
 
 If you want your shell sessions to each have different active configs, try this in your `~/.profile` or `~/.zshrc` or `~/.bashrc`:
 

--- a/README.md
+++ b/README.md
@@ -298,3 +298,14 @@ Valid patch directories include:
 [nvm]: https://github.com/nvm-sh/nvm
 [platform-prerequisites]: https://electronjs.org/docs/development/build-instructions-gn#platform-prerequisites
 [sanitizers]: https://github.com/google/sanitizers
+
+## Per-Session Active Configs
+
+If you want your shell sessions to each have different active configs, try this in your `~/.profile` or `~/.zshrc` or `~/.bashrc`:
+
+```sh
+export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+```
+
+This will create per-shell temporary files in which he active config file can be changed with `e use`.
+

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -7,12 +7,16 @@ const { color } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const goma = require('./utils/goma');
 
+const preferredFormat = process.env.EVM_FORMAT || 'json'; // yaml yml json
 const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'configs');
+
+// If you want your shell sessions to each have different active configs,
+// try this in your ~/.profile or ~/.zshrc or ~/.bashrc:
+// export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
 const currentFiles = _.compact([
   process.env.EVM_CURRENT_FILE,
   path.resolve(configRoot, 'evm-current.txt'),
 ]);
-const preferredFormat = process.env.EVM_FORMAT || 'json'; // yaml yml json
 
 function buildPath(name, suffix) {
   return path.resolve(configRoot, `evm.${name}.${suffix}`);


### PR DESCRIPTION
The intent is to follow the same workflow as nvm: e has a default active config (just as nvm has a default active version of Node.js), but that can be overridden by the user on a per-shell basis.

What's the same as EVM_SESSION_ID: since `e` is a JS script and can't modify its caller's environment variables, the goal is accomplished by having more than one 'current' file. The default file is $EVM_CONFIG/evm-current.txt. An optional environment variable specifies where to find an optional file to override the default.

What's different from EVM_SESSION_ID: EVM_CURRENT_FILE specifies the filename itself, so evm-config.js doesn't need new folder code and $EVM_CONFIG/sessions/ doesn't accumulate dead session folders. Instead, the file can be in $TMPDIR so that the OS will clean it up later. Also, the `EVM_CURRENT` code has also been removed since this new feature does the same thing in a way that's more like nvm.
    
To opt in to this behavior, one would add something like `export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXXX.txt)"` to one's ~/\.[profile|bashrc|zshrc].
