### PR TITLE
fix: buildtools now downloading for cache-only

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -33,6 +33,8 @@ function ensureGNGen(config) {
 
 function runNinja(config, target, ninjaArgs) {
   if (config.goma !== 'none') {
+    goma.downloadAndPrepare();
+
     if (config.goma === 'cluster') {
       const authenticated = goma.isAuthenticated(config.root);
       if (!authenticated) {

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -87,8 +87,6 @@ function downloadAndPrepareGoma() {
 function gomaIsAuthenticated() {
   if (!isSupportedPlatform) return false;
 
-  downloadAndPrepareGoma();
-
   const loggedInInfo = childProcess.execFileSync('python', ['goma_auth.py', 'info'], {
     cwd: gomaDir,
   });


### PR DESCRIPTION
goma util functions were structured such that `downloadAndPrepareGoma` was only run if you were authenticating or checking for auth status, which meant that cache-only goma users would not see goma properly downloaded to `third_party`.

The following failure would occur (as seen by cache-only user):
```sh
Running "goma_ctl.py ensure_start" in C:\Users\hepadala\build-tools\third_party\goma
ERROR Error: spawnSync python ENOENT
    at Object.spawnSync (internal/child_process.js:1041:20)
    at spawnSync (child_process.js:607:24)
    at Object.execFileSync (child_process.js:634:15)
    at Object.ensureGomaStart [as ensure] (C:\Users\hepadala\build-tools\src\utils\goma.js:113:16)
    at runNinja (C:\Users\hepadala\build-tools\src\e-build.js:46:10)
    at Object.<anonymous> (C:\Users\hepadala\build-tools\src\e-build.js:102:3)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
ERROR Error: Command failed: node C:\Users\hepadala\build-tools\src\e build
    at checkExecSyncError (child_process.js:621:11)
    at Object.execFileSync (child_process.js:639:15)
    at Object.<anonymous> (C:\Users\hepadala\build-tools\src\e-init.js:192:18)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11
```

cc @MarshallOfSound 