### PR TITLE
fix: use gn.bat on win32

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -13,8 +13,9 @@ const goma = require('./utils/goma');
 function runGNGen(config) {
   depot.ensure();
 
+  const gnExec = os.platform() === 'win32' ? 'gn.bat' : 'gn';
   const gn_args = config.gen.args.join(' ').replace(/\"/g, '\\"'); // gn parses this part -- inner quotes must be escaped
-  const exec = `${path.resolve(depot.path, 'gn.py')} gen "out/${
+  const exec = `${path.resolve(depot.path, gnExec)} gen "out/${
     config.gen.out
   }" --args="${gn_args}"`;
   const opts = { cwd: path.resolve(config.root, 'src') };


### PR DESCRIPTION
We were directly invoking `gn.py`, which skips over the two platform-specific invokers, `gn` and `gn.bat`. Those two files run important path setup steps, and so we should be mimicking the approach taken by Chromium as seen [here](https://source.chromium.org/chromium/chromium/src/+/master:build/check_gn_headers.py;l=98?q=%22gn.bat%22&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F).

cc @ckerr @MarshallOfSound 