### PR TITLE
fix: windows tests failing

### DIFF
--- a/tests/e-show-spec.js
+++ b/tests/e-show-spec.js
@@ -138,6 +138,8 @@ describe('e-show', () => {
         acc[k] = v;
         return acc;
       }, {});
-    expect(Object.keys(env).sort()).toEqual(['CHROMIUM_BUILDTOOLS_PATH', 'GIT_CACHE_PATH']);
+    expect(Object.keys(env).sort()).toEqual(
+      expect.arrayContaining(['CHROMIUM_BUILDTOOLS_PATH', 'GIT_CACHE_PATH']),
+    );
   });
 });

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -1,5 +1,6 @@
 const childProcess = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 // for `rm -rf`'ing the sandbox tmpdir
@@ -16,7 +17,7 @@ function runSync(args, options) {
   // jest doesn't directly support coverage of exec'ed scripts,
   // but this workaround of invoking nyc in spawn gets the job done.
   // https://github.com/facebook/jest/issues/3190#issuecomment-354758036
-  const spawnCmd = 'nyc';
+  const spawnCmd = os.platform() === 'win32' ? 'nyc.cmd' : 'nyc';
   const spawnArgs = ['--reporter', 'none', 'node'];
   const debug = false;
 


### PR DESCRIPTION
I'm running Windows 10 64-bit and after running `yarn test`, I received failures.

First issue was caused by `nyc` not spawning. Had to switch to use `npm.cmd` to fix it.

Second issue was a test not checking for Windows-only environment vars getting set.
https://github.com/electron/build-tools/blob/f9aa0d26bc37dfb52cdd7b692b2963a0148d09b6/src/e-init.js#L39-L44