### PR TITLE
feat: use an electron provided windows toolchain

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -13,13 +13,6 @@ const goma = require('./utils/goma');
 const depot = require('./utils/depot-tools');
 const { checkGlobalGitConfig } = require('./utils/git');
 
-function getVSReleaseLine() {
-  const exec = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe';
-  const args = ['-latest', '-property', 'catalog_productLineVersion'];
-  const opts = { encoding: 'utf8' };
-  return childProcess.execFileSync(exec, args, opts).trim();
-}
-
 function createConfig(options) {
   const root = resolvePath(options.root);
   const homedir = os.homedir();
@@ -35,13 +28,6 @@ function createConfig(options) {
   if (options.lsan) gn_args.push('is_lsan=true');
   if (options.msan) gn_args.push('is_msan=true');
   if (options.tsan) gn_args.push('is_tsan=true');
-
-  // os-specific environment variables
-  const platform_env = {};
-  if (os.platform() === 'win32') {
-    platform_env.DEPOT_TOOLS_WIN_TOOLCHAIN = '0';
-    platform_env.GYP_MSVS_VERSION = getVSReleaseLine();
-  }
 
   return {
     goma: options.goma,
@@ -63,7 +49,6 @@ function createConfig(options) {
       GIT_CACHE_PATH: process.env.GIT_CACHE_PATH
         ? resolvePath(process.env.GIT_CACHE_PATH)
         : path.resolve(homedir, '.git_cache'),
-      ...platform_env,
     },
   };
 }

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -31,7 +31,16 @@ function runGClientSync(config, syncArgs) {
 
   const exec = 'python';
   const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', ...syncArgs];
-  const opts = { cwd: srcdir };
+  const opts = {
+    cwd: srcdir,
+    env: {
+      DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
+      DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL:
+        'https://electron-build-tools.s3-us-west-2.amazonaws.com/win32/toolchains/_',
+      GYP_MSVS_HASH_9ff60e43ba91947baca460d0ca3b1b980c3a2c23:
+        '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
+    },
+  };
   depot.execFileSync(config, exec, args, opts);
   setOrigin(path.resolve(srcdir, 'electron'), config.origin.electron);
   setOrigin(path.resolve(srcdir, 'third_party', 'electron_node'), config.origin.node);

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -33,13 +33,6 @@ function runGClientSync(config, syncArgs) {
   const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', ...syncArgs];
   const opts = {
     cwd: srcdir,
-    env: {
-      DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
-      DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL:
-        'https://electron-build-tools.s3-us-west-2.amazonaws.com/win32/toolchains/_',
-      GYP_MSVS_HASH_9ff60e43ba91947baca460d0ca3b1b980c3a2c23:
-        '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
-    },
   };
   depot.execFileSync(config, exec, args, opts);
   setOrigin(path.resolve(srcdir, 'electron'), config.origin.electron);

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -54,6 +54,11 @@ function depotOpts(config, opts = {}) {
     PYTHONDONTWRITEBYTECODE: '1', // depot needs it
     DEPOT_TOOLS_METRICS: '0', // disable depot metrics
     ...process.env,
+    DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
+    DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL:
+      'https://electron-build-tools.s3-us-west-2.amazonaws.com/win32/toolchains/_',
+    GYP_MSVS_HASH_9ff60e43ba91947baca460d0ca3b1b980c3a2c23:
+      '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
     ...config.env,
     ...opts.env,
   };


### PR DESCRIPTION
Fixes #93 

This works at least for master, haven't tested older branches but we might need to make toolchains for older branches separately.  If chromium changes the hash we'll need to make a new toolchain and put it in the env here.