### PR TITLE
fix: check git settings before we do anything

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -152,6 +152,11 @@ if (options.import && !options.out) {
 }
 
 try {
+  // Check global git settings that need to be enabled on Windows.
+  if (os.platform() === 'win32') {
+    checkGlobalGitConfig();
+  }
+
   // make sure the config name is new
   const filename = evmConfig.pathOf(name);
   if (!options.force && fs.existsSync(filename)) {
@@ -186,11 +191,6 @@ try {
   // maybe authenticate with Goma
   if (config.goma === 'cluster') {
     goma.auth();
-  }
-
-  // Check global git settings that need to be enabled on Windows.
-  if (os.platform() === 'win32') {
-    checkGlobalGitConfig();
   }
 
   // (maybe) build Electron


### PR DESCRIPTION
With the old code we were syncing then checking git settings, at that point it was too late if the settings were wrong, we had a polluted cache.  We should fail-fast here if the settings are wrong