### PR TITLE
feat: make build-tools error-correcting on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "open": "^6.4.0",
     "path-key": "^3.1.0",
     "readline-sync": "^1.4.10",
-    "stream-progressbar": "^1.3.0"
+    "stream-progressbar": "^1.3.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "husky": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node-gyp": "^6.1.0",
     "open": "^6.4.0",
     "path-key": "^3.1.0",
+    "readline-sync": "^1.4.10",
     "stream-progressbar": "^1.3.0"
   },
   "devDependencies": {

--- a/src/e
+++ b/src/e
@@ -7,6 +7,10 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const { refreshPathVariable } = require('./utils/refresh-path');
+
+// Refresh the PATH variable at the top of this shell so that retries in the same shell get the latest PATH variable
+refreshPathVariable();
 
 program.description('Electron build tool').usage('<command> [commandArgs...]');
 

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -12,6 +12,7 @@ const { resolvePath, ensureDir } = require('./utils/paths');
 const goma = require('./utils/goma');
 const depot = require('./utils/depot-tools');
 const { checkGlobalGitConfig } = require('./utils/git');
+const { checkPlatformDependencies } = require('./utils/deps-check');
 
 function createConfig(options) {
   const root = resolvePath(options.root);
@@ -141,6 +142,8 @@ try {
   if (os.platform() === 'win32') {
     checkGlobalGitConfig();
   }
+
+  checkPlatformDependencies();
 
   // make sure the config name is new
   const filename = evmConfig.pathOf(name);

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -33,13 +33,6 @@ function runGClientSync(config, syncArgs) {
   const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', ...syncArgs];
   const opts = {
     cwd: srcdir,
-    env: {
-      DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
-      DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL:
-        'https://electron-build-tools.s3-us-west-2.amazonaws.com/win32/toolchains/_',
-      GYP_MSVS_HASH_9ff60e43ba91947baca460d0ca3b1b980c3a2c23:
-        '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
-    },
   };
   depot.execFileSync(config, exec, args, opts);
   setOrigin(path.resolve(srcdir, 'electron'), config.origin.electron);

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -33,6 +33,13 @@ function runGClientSync(config, syncArgs) {
   const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', ...syncArgs];
   const opts = {
     cwd: srcdir,
+    env: {
+      DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
+      DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL:
+        'https://electron-build-tools.s3-us-west-2.amazonaws.com/win32/toolchains/_',
+      GYP_MSVS_HASH_9ff60e43ba91947baca460d0ca3b1b980c3a2c23:
+        '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
+    },
   };
   depot.execFileSync(config, exec, args, opts);
   setOrigin(path.resolve(srcdir, 'electron'), config.origin.electron);

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -6,7 +6,9 @@ const { whichAndFix } = require('./which');
 
 const spawnSyncWithLog = (cmd, args) => {
   console.log(color.childExec(cmd, args, {}));
-  return cp.spawnSync(cmd, args);
+  return cp.spawnSync(cmd, args, {
+    stdio: 'inherit',
+  });
 };
 
 const deps = {

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -15,13 +15,6 @@ const spawnSyncWithLog = (cmd, args) => {
 const deps = {
   win32: [
     {
-      cmd: 'python',
-      fix: () => {
-        spawnSyncWithLog('choco', ['install', 'python2', '--yes']);
-      },
-      deps: ['choco'],
-    },
-    {
       cmd: 'choco',
       fix: () => {
         spawnSyncWithLog('powershell', [
@@ -29,6 +22,23 @@ const deps = {
           "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
         ]);
       },
+    },
+    {
+      cmd: 'python',
+      fix: () => {
+        spawnSyncWithLog('choco', ['install', 'python2', '--yes']);
+      },
+      deps: ['choco'],
+    },
+    {
+      cmd: 'pywin32',
+      check: () => {
+        return cp.spawnSync('python', ['-c', 'import win32process']).status === 0;
+      },
+      fix: () => {
+        spawnSyncWithLog('choco', ['install', 'python2', '--yes']);
+      },
+      deps: ['choco'],
     },
   ],
 };
@@ -48,7 +58,7 @@ const checkPlatformDependencies = () => {
         newDeps.push(dep);
         continue;
       }
-      whichAndFix(dep.cmd, dep.fix);
+      whichAndFix(dep.cmd, dep.check, dep.fix);
       for (const oDep of depsToResolve) {
         if (oDep === dep) continue;
         if (oDep.deps) {

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -12,7 +12,9 @@ const deps = {
   win32: [
     {
       cmd: 'python',
-      fix: () => {},
+      fix: () => {
+        spawnSyncWithLog('choco', ['install', 'python2']);
+      },
       deps: ['choco'],
     },
     {

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -44,9 +44,6 @@ const deps = {
 };
 
 const checkPlatformDependencies = () => {
-  // Refresh the PATH variable at the top of this shell so that retries in the same shell get the latest PATH variable
-  refreshPathVariable();
-
   if (!deps[process.platform]) return;
   let depsToResolve = deps[process.platform];
   let previousLength = depsToResolve.length;

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -6,9 +6,10 @@ const { whichAndFix } = require('./which');
 
 const spawnSyncWithLog = (cmd, args) => {
   console.log(color.childExec(cmd, args, {}));
-  return cp.spawnSync(cmd, args, {
-    stdio: 'inherit',
-  });
+  const result = cp.spawnSync(cmd, args);
+  if (result.status !== 0) {
+    throw new Error(`Failed to run "${cmd} ${args.join(' ')}"`);
+  }
 };
 
 const deps = {
@@ -16,7 +17,7 @@ const deps = {
     {
       cmd: 'python',
       fix: () => {
-        spawnSyncWithLog('choco', ['install', 'python2']);
+        spawnSyncWithLog('choco', ['install', 'python2', '--yes']);
       },
       deps: ['choco'],
     },

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -44,6 +44,9 @@ const deps = {
 };
 
 const checkPlatformDependencies = () => {
+  // Use latest PATH variable when searching for deps
+  refreshPathVariable();
+
   if (!deps[process.platform]) return;
   let depsToResolve = deps[process.platform];
   let previousLength = depsToResolve.length;

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -1,0 +1,66 @@
+const cp = require('child_process');
+
+const { color } = require('./logging');
+const { whichAndFix } = require('./which');
+
+const spawnSyncWithLog = (cmd, args) => {
+  console.log(color.childExec(cmd, args, {}));
+  return cp.spawnSync(cmd, args);
+};
+
+const deps = {
+  win32: [
+    {
+      cmd: 'python',
+      fix: () => {},
+      deps: ['choco'],
+    },
+    {
+      cmd: 'choco',
+      fix: () => {
+        spawnSyncWithLog('powershell', [
+          '-Command',
+          "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))",
+        ]);
+      },
+    },
+  ],
+};
+
+const checkPlatformDependencies = () => {
+  if (!deps[process.platform]) return;
+  let depsToResolve = deps[process.platform];
+  let previousLength = depsToResolve.length;
+  while (depsToResolve.length > 0) {
+    const newDeps = [];
+    for (const dep of depsToResolve) {
+      // Still waiting for stuff
+      if (dep.deps && dep.deps.length > 0) {
+        newDeps.push(dep);
+        continue;
+      }
+      whichAndFix(dep.cmd, dep.fix);
+      for (const oDep of depsToResolve) {
+        if (oDep === dep) continue;
+        if (oDep.deps) {
+          oDep.deps = oDep.deps.filter(d => d !== dep.cmd);
+        }
+      }
+    }
+    depsToResolve = newDeps;
+
+    if (previousLength === depsToResolve.length) {
+      throw new Error(
+        'Unable to resolve dependencies, this is impossible so please raise an issue on the build-tools repository',
+      );
+    }
+  }
+};
+
+module.exports = {
+  checkPlatformDependencies,
+};
+
+if (process.mainModule === module) {
+  checkPlatformDependencies();
+}

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -1,6 +1,7 @@
 const cp = require('child_process');
 
 const { color } = require('./logging');
+const { refreshPathVariable } = require('./refresh-path');
 const { whichAndFix } = require('./which');
 
 const spawnSyncWithLog = (cmd, args) => {
@@ -30,6 +31,9 @@ const deps = {
 };
 
 const checkPlatformDependencies = () => {
+  // Refresh the PATH variable at the top of this shell so that retries in the same shell get the latest PATH variable
+  refreshPathVariable();
+
   if (!deps[process.platform]) return;
   let depsToResolve = deps[process.platform];
   let previousLength = depsToResolve.length;

--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -36,7 +36,7 @@ const deps = {
         return cp.spawnSync('python', ['-c', 'import win32process']).status === 0;
       },
       fix: () => {
-        spawnSyncWithLog('choco', ['install', 'python2', '--yes']);
+        spawnSyncWithLog('choco', ['install', 'pywin32', '--yes']);
       },
       deps: ['choco'],
     },

--- a/src/utils/get-path.bat
+++ b/src/utils/get-path.bat
@@ -1,0 +1,48 @@
+@echo off
+::
+:: Based on choco RefreshEnv.cmd --> https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/redirects/RefreshEnv.cmd
+::
+:: This file will load the latest version of every env var and then output the PATH environment variable to be loaded back into the node process
+
+goto main
+
+:: Set one environment variable from registry key
+:SetFromReg
+    "%WinDir%\System32\Reg" QUERY "%~1" /v "%~2" > "%TEMP%\_envset.tmp" 2>NUL
+    for /f "usebackq skip=2 tokens=2,*" %%A IN ("%TEMP%\_envset.tmp") do (
+        echo/set %~3=%%B
+    )
+    goto :EOF
+
+:: Get a list of environment variables from registry
+:GetRegEnv
+    "%WinDir%\System32\Reg" QUERY "%~1" > "%TEMP%\_envget.tmp"
+    for /f "usebackq skip=2" %%A IN ("%TEMP%\_envget.tmp") do (
+        if /I not "%%~A"=="Path" (
+            call :SetFromReg "%~1" "%%~A" "%%~A"
+        )
+    )
+    goto :EOF
+
+:main
+    echo/@echo off >"%TEMP%\_env.cmd"
+
+    :: Slowly generating final file
+    call :GetRegEnv "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" >> "%TEMP%\_env.cmd"
+    call :GetRegEnv "HKCU\Environment">>"%TEMP%\_env.cmd" >> "%TEMP%\_env.cmd"
+
+    :: Special handling for PATH - mix both User and System
+    call :SetFromReg "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" Path Path_HKLM >> "%TEMP%\_env.cmd"
+    call :SetFromReg "HKCU\Environment" Path Path_HKCU >> "%TEMP%\_env.cmd"
+
+    :: Caution: do not insert space-chars before >> redirection sign
+    echo/set Path=%%Path_HKLM%%;%%Path_HKCU%% >> "%TEMP%\_env.cmd"
+
+    :: Cleanup
+    del /f /q "%TEMP%\_envset.tmp" 2>nul
+    del /f /q "%TEMP%\_envget.tmp" 2>nul
+
+    :: Set these variables
+    call "%TEMP%\_env.cmd"
+
+    echo %PATH%

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -1,15 +1,27 @@
 const cp = require('child_process');
 
+const { maybeAutoFix } = require('./maybe-auto-fix');
+const { color } = require('./logging');
+
+const spawnSyncWithLog = (cmd, args) => {
+  console.log(color.childExec(cmd, args, {}));
+  return cp.spawnSync(cmd, args);
+};
+
 function checkGlobalGitConfig() {
   const { stdout: fileMode } = cp.spawnSync('git', ['config', '--global', 'core.filemode']);
 
   if (fileMode.toString().trim() !== 'false') {
-    throw new Error('git config --global core.filemode must be set to false.');
+    maybeAutoFix(() => {
+      spawnSyncWithLog('git', ['config', '--global', 'core.filemode', 'false']);
+    }, new Error('git config --global core.filemode must be set to false.'));
   }
 
   const { stdout: autoCrlf } = cp.spawnSync('git', ['config', '--global', 'core.autocrlf']);
   if (autoCrlf.toString().trim() !== 'false') {
-    throw new Error('git config --global core.autocrlf must be set to false.');
+    maybeAutoFix(() => {
+      spawnSyncWithLog('git', ['config', '--global', 'core.autocrlf', 'false']);
+    }, new Error('git config --global core.autocrlf must be set to false.'));
   }
 
   const { stdout: autoSetupRebase } = cp.spawnSync('git', [
@@ -18,7 +30,9 @@ function checkGlobalGitConfig() {
     'branch.autosetuprebase',
   ]);
   if (autoSetupRebase.toString().trim() !== 'always') {
-    throw new Error('git config --global branch.autosetuprebase must be set to always.');
+    maybeAutoFix(() => {
+      spawnSyncWithLog('git', ['config', '--global', 'branch.autosetuprebase', 'always']);
+    }, new Error('git config --global branch.autosetuprebase must be set to always.'));
   }
 }
 

--- a/src/utils/maybe-auto-fix.js
+++ b/src/utils/maybe-auto-fix.js
@@ -1,0 +1,17 @@
+const readlineSync = require('readline-sync');
+const { color } = require('./logging');
+
+const maybeAutoFix = (fn, err) => {
+  // If we're running in CI we can't prompt the user
+  if (process.env.CI) throw err;
+  if (!process.stdin.isTTY) throw err;
+  console.error(color.warn, 'A fixable error has occurred');
+  console.error('-->', err.message);
+  if (!readlineSync.keyInYN(`Do you want build-tools to try fix this for you?`)) throw err;
+  console.log('');
+  fn();
+};
+
+module.exports = {
+  maybeAutoFix,
+};

--- a/src/utils/maybe-auto-fix.js
+++ b/src/utils/maybe-auto-fix.js
@@ -2,6 +2,7 @@ const readlineSync = require('readline-sync');
 const { color } = require('./logging');
 
 const maybeAutoFix = (fn, err) => {
+  if (process.env.ELECTRON_BUILD_TOOLS_AUTO_FIX) return fn();
   // If we're running in CI we can't prompt the user
   if (process.env.CI) throw err;
   if (!process.stdin.isTTY) throw err;

--- a/src/utils/refresh-path.js
+++ b/src/utils/refresh-path.js
@@ -1,0 +1,14 @@
+const cp = require('child_process');
+const path = require('path');
+
+const refreshPathVariable = () => {
+  if (process.platform === 'win32') {
+    const output = cp.execSync(path.resolve(__dirname, 'get-path.bat'));
+    const pathOut = output.toString();
+    process.env.PATH = pathOut;
+  }
+};
+
+module.exports = {
+  refreshPathVariable,
+};

--- a/src/utils/which.js
+++ b/src/utils/which.js
@@ -5,7 +5,6 @@ const { refreshPathVariable } = require('./refresh-path');
 
 const whichAndFix = (cmd, check, fix) => {
   const found = check ? check() : !!which(cmd, { nothrow: true });
-  console.log(cmd, check, fix, found);
   if (!found) {
     maybeAutoFix(
       fix,

--- a/src/utils/which.js
+++ b/src/utils/which.js
@@ -5,6 +5,7 @@ const { refreshPathVariable } = require('./refresh-path');
 
 const whichAndFix = (cmd, check, fix) => {
   const found = check ? check() : !!which(cmd, { nothrow: true });
+  console.log(cmd, check, fix, found);
   if (!found) {
     maybeAutoFix(
       fix,

--- a/src/utils/which.js
+++ b/src/utils/which.js
@@ -3,8 +3,8 @@ const which = require('which').sync;
 const { maybeAutoFix } = require('./maybe-auto-fix');
 const { refreshPathVariable } = require('./refresh-path');
 
-const whichAndFix = (cmd, fix) => {
-  const found = !!which(cmd, { nothrow: true });
+const whichAndFix = (cmd, check, fix) => {
+  const found = check ? check() : !!which(cmd, { nothrow: true });
   if (!found) {
     maybeAutoFix(
       fix,
@@ -15,7 +15,7 @@ const whichAndFix = (cmd, fix) => {
 
     refreshPathVariable();
 
-    if (!which(cmd, { nothrow: true })) {
+    if (!(check ? check() : which(cmd, { nothrow: true }))) {
       throw new Error(
         `A required dependency "${cmd}" could not be located and we could not install it for some reason, it probably has to be installed manually.`,
       );

--- a/src/utils/which.js
+++ b/src/utils/which.js
@@ -1,0 +1,19 @@
+const which = require('which').sync;
+
+const { maybeAutoFix } = require('./maybe-auto-fix');
+
+const whichAndFix = (cmd, fix) => {
+  const found = !!which(cmd, { nothrow: true });
+  if (!found) {
+    maybeAutoFix(
+      fix,
+      new Error(
+        `A required dependency "${cmd}" could not be located, it probably has to be installed.`,
+      ),
+    );
+  }
+};
+
+module.exports = {
+  whichAndFix,
+};

--- a/src/utils/which.js
+++ b/src/utils/which.js
@@ -1,6 +1,7 @@
 const which = require('which').sync;
 
 const { maybeAutoFix } = require('./maybe-auto-fix');
+const { refreshPathVariable } = require('./refresh-path');
 
 const whichAndFix = (cmd, fix) => {
   const found = !!which(cmd, { nothrow: true });
@@ -11,6 +12,14 @@ const whichAndFix = (cmd, fix) => {
         `A required dependency "${cmd}" could not be located, it probably has to be installed.`,
       ),
     );
+
+    refreshPathVariable();
+
+    if (!which(cmd, { nothrow: true })) {
+      throw new Error(
+        `A required dependency "${cmd}" could not be located and we could not install it for some reason, it probably has to be installed manually.`,
+      );
+    }
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,6 +3639,11 @@ readable-stream@^2.0.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
+
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,7 +4548,7 @@ which@^1.2.9, which@^1.3.0, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
With these changes I can install Node, Git and `build-tools` and run 

`e init --root=~/electron --bootstrap testing` and it Just Works out of the box, it will prompt to install missing dependencies, fix incorrect git configuration, etc.

Closes #102 
Closes #104 

Currently stacked on top of #96 for Better Windows Reasons