### PR TITLE
feat: auto-update the build-tools every 4 hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 node_modules
 package-lock.json
 third_party
+.update

--- a/src/e
+++ b/src/e
@@ -1,12 +1,35 @@
 #!/usr/bin/env node
 
 const childProcess = require('child_process');
+const fs = require('fs');
 const program = require('commander');
+const path = require('path');
 
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+
+const updateCheckTSFile = path.resolve(__dirname, '..', '.update');
+const lastCheck = fs.existsSync(updateCheckTSFile)
+  ? parseInt(fs.readFileSync(updateCheckTSFile, 'utf8'), 10)
+  : 0;
+if (isNaN(lastCheck) || Date.now() - lastCheck > 1000 * 60 * 60 * 4) {
+  childProcess.spawnSync(process.execPath, ['e-check-for-updates.js'], {
+    cwd: __dirname,
+    stdio: 'inherit',
+  });
+  fs.writeFileSync(updateCheckTSFile, `${Date.now()}`);
+  const result = childProcess.spawnSync(
+    process.execPath,
+    process.argv[0] === process.execPath ? process.argv.slice(1) : process.argv,
+    {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+    },
+  );
+  process.exit(result.status);
+}
 
 program.description('Electron build tool').usage('<command> [commandArgs...]');
 
@@ -90,7 +113,8 @@ program
   .command(
     'load-xcode',
     'Loads required versions of Xcode and the macOS SDK and symlinks them.  This may require sudo',
-  );
+  )
+  .command('check-for-updates', 'a');
 
 program
   .command('depot-tools')

--- a/src/e-check-for-updates.js
+++ b/src/e-check-for-updates.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const cp = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const program = require('commander');
+
+const evmConfig = require('./evm-config');
+const { color, fatal } = require('./utils/logging');
+const depot = require('./utils/depot-tools');
+
+program
+  .allowUnknownOption()
+  .description('Check for build-tools updates')
+  .parse(process.argv);
+
+try {
+  console.log('Checking for build-tools updates');
+  const baseDir = path.resolve(__dirname, '..');
+
+  const headBefore = cp
+    .execSync('git rev-parse --verify HEAD')
+    .toString('utf8')
+    .trim();
+  console.log(
+    color.childExec('git', ['pull'], {
+      cwd: baseDir,
+    }),
+  );
+  cp.execSync('git pull', {
+    cwd: baseDir,
+  });
+  const headAfter = cp
+    .execSync('git rev-parse --verify HEAD')
+    .toString('utf8')
+    .trim();
+  if (headBefore !== headAfter) {
+    console.log(
+      color.childExec('npx', ['yarn'], {
+        cwd: baseDir,
+      }),
+    );
+    cp.execSync('npx yarn', {
+      cwd: baseDir,
+    });
+    console.log('Updated to Latest Build Tools');
+  } else {
+    console.log('Already Up To Date');
+  }
+} catch (e) {
+  fatal(e);
+}


### PR DESCRIPTION
Every four hours the next `build-tools` command you run will try to `git pull` and `npx yarn` if your HEAD changed.

This is rudimentary but should keep users up to date with important things like `goma` and `xcode`.