### PR TITLE
feat: switch to Xcode 11.1

### DIFF
--- a/src/utils/hash.js
+++ b/src/utils/hash.js
@@ -1,6 +1,0 @@
-const fs = require('fs');
-const hasha = require('hasha');
-
-fs.createReadStream(process.argv[2])
-  .pipe(hasha.stream({ algorithm: 'md5' }))
-  .pipe(process.stdout);


### PR DESCRIPTION
Electron 8, 9 and master are all on Xcode 11.  Let's get cache hits from CI again

I'm going to work after this PR on detecting which Xcode version to use based on the `circle.yml` file which should mean we won't have to manually switch versions like this too often.

This has a little bit of work towards handling multiple Xcode versions and hot-swapping them