### PR TITLE
fix: gracefully catch auth error

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -87,9 +87,15 @@ function downloadAndPrepareGoma() {
 function gomaIsAuthenticated() {
   if (!isSupportedPlatform) return false;
 
-  const loggedInInfo = childProcess.execFileSync('python', ['goma_auth.py', 'info'], {
-    cwd: gomaDir,
-  });
+  let loggedInInfo;
+  try {
+    loggedInInfo = childProcess.execFileSync('python', ['goma_auth.py', 'info'], {
+      cwd: gomaDir,
+      stdio: ['ignore'],
+    });
+  } catch {
+    return false;
+  }
 
   const loggedInPattern = /^Login as (\w+\s\w+)$/;
   return loggedInPattern.test(loggedInInfo.toString().trim());


### PR DESCRIPTION
If auth failed previously it'd explode on your terminal like:

```sh
electron on git:master ❯ e d goma_auth info                                      10:06AM
Running "python goma_auth.py info" in /Users/codebytere/build-tools/third_party/goma
E0305 10:08:04.187968 336999872 goma_fetch.cc:249] fetch POST https://login.microsoftonline.com/electronad.onmicrosoft.com/oauth2/token err=-1  Got HTTP error:400 dest=login.microsoftonline.com:443 url_path_prefix=/electronad.onmicrosoft.com/oauth2/token use_ssl socket_read_timeout=10s retry_backoff=500ms .. 5s
Traceback (most recent call last):
  File "goma_auth.py", line 669, in <module>
    sys.exit(main())
  File "goma_auth.py", line 665, in main
    return action()
  File "goma_auth.py", line 584, in Info
    err = VerifyRefreshToken(config)
  File "goma_auth.py", line 513, in VerifyRefreshToken
    resp = json.loads(HttpPostRequest(config['token_uri'], post_data))
  File "goma_auth.py", line 228, in HttpPostRequest
    return subprocess.check_output(cmd)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 566, in check_output
    process = Popen(stdout=PIPE, *popenargs, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 63] File name too long
ERROR Failed to run command, exit code was "1", error was 'undefined'
```

this PR handles that gracefully by catching the error and exiting instead, so now you'll see:

```sh
electron on git:master ❯ e build                                                 10:11AM
ERROR Error: Goma not authenticated. Either sign in with "e d goma_auth login" or change your config.goma value to 'cache-only'
    at runNinja (/Users/codebytere/build-tools/src/e-build.js:43:15)
    at Object.<anonymous> (/Users/codebytere/build-tools/src/e-build.js:106:3)
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
```
