### PR TITLE
fix: stdio should be inherit in goma.auth

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -108,7 +108,7 @@ function authenticateGoma() {
 
   if (!gomaIsAuthenticated()) {
     console.log(color.childExec('goma_auth.py', ['login'], { cwd: gomaDir }));
-    childProcess.execFileSync('python', ['goma_auth.py', 'login'], { cwd: gomaDir });
+    childProcess.execFileSync('python', ['goma_auth.py', 'login'], { cwd: gomaDir, stdio: 'inherit' });
   }
 }
 


### PR DESCRIPTION
goma.auth needs to inherit stdin to accept data policy.