### PR TITLE
chore: make the default sync command ignore locks and be verbose

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -30,7 +30,15 @@ function runGClientSync(config, syncArgs) {
   depot.ensure();
 
   const exec = 'python';
-  const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', ...syncArgs];
+  const args = [
+    'gclient.py',
+    'sync',
+    '--with_branch_heads',
+    '--with_tags',
+    '-vv',
+    '--ignore_locks',
+    ...syncArgs,
+  ];
   const opts = { cwd: srcdir };
   depot.execFileSync(config, exec, args, opts);
   setOrigin(path.resolve(srcdir, 'electron'), config.origin.electron);


### PR DESCRIPTION
This helps for debugging and it's not like any of us are using network drives / two syncs at a time