### PR TITLE
fix: only exit if the exit code is not 0

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -55,8 +55,8 @@ function runNinja(config, target, ninjaArgs) {
           console.error(
             `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
           );
+          process.exit(status);
         }
-        process.exit(status);
       }
     }
 


### PR DESCRIPTION
Previously running `e build` without an authenticated goma would result in you being prompted to auth and then having to run `e build` again.  This fixes that