### PR TITLE
chore: prevent accidental publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": ">= 10.12.0"
   },
   "main": "null",
+  "private": true,
   "scripts": {
     "lint": "prettier --check \"src/*.js\" \"tests/*.js\" \"src/e\"",
     "prettier:write": "prettier --write \"src/*.js\" \"tests/*.js\" \"src/e\"",


### PR DESCRIPTION
Prevent accidental publish of this repo to npm, as in order to preserve auto-update functionality we plan to use https://github.com/electron/build-tools-installer.