### PR TITLE
fix: set correct cwd in check-for-updates

### DIFF
--- a/src/e
+++ b/src/e
@@ -114,7 +114,7 @@ program
     'load-xcode',
     'Loads required versions of Xcode and the macOS SDK and symlinks them.  This may require sudo',
   )
-  .command('check-for-updates', 'a');
+  .command('check-for-updates', 'Check for build-tools updates');
 
 program
   .command('depot-tools')

--- a/src/e-check-for-updates.js
+++ b/src/e-check-for-updates.js
@@ -19,15 +19,20 @@ try {
   console.log('Checking for build-tools updates');
   const baseDir = path.resolve(__dirname, '..');
 
+  const execOpts = {
+    cwd: baseDir,
+  };
+
   const headBefore = cp
-    .execSync('git rev-parse --verify HEAD')
+    .execSync('git rev-parse --verify HEAD', execOpts)
     .toString('utf8')
     .trim();
 
   const currentBranch = cp
-    .execSync('git rev-parse --abbrev-ref HEAD')
+    .execSync('git rev-parse --abbrev-ref HEAD', execOpts)
     .toString('utf8')
     .trim();
+  console.log({ headBefore, currentBranch });
 
   if (currentBranch !== 'master') {
     throw new Error(
@@ -35,16 +40,10 @@ try {
     );
   }
 
-  console.log(
-    color.childExec('git', ['pull'], {
-      cwd: baseDir,
-    }),
-  );
-  cp.execSync('git pull', {
-    cwd: baseDir,
-  });
+  console.log(color.childExec('git', ['pull'], execOpts));
+  cp.execSync('git pull', execOpts);
   const headAfter = cp
-    .execSync('git rev-parse --verify HEAD')
+    .execSync('git rev-parse --verify HEAD', execOpts)
     .toString('utf8')
     .trim();
   if (headBefore !== headAfter) {
@@ -53,9 +52,7 @@ try {
         cwd: baseDir,
       }),
     );
-    cp.execSync('npx yarn', {
-      cwd: baseDir,
-    });
+    cp.execSync('npx yarn', execOpts);
     console.log('Updated to Latest Build Tools');
   } else {
     console.log('Already Up To Date');

--- a/src/e-check-for-updates.js
+++ b/src/e-check-for-updates.js
@@ -32,7 +32,6 @@ try {
     .execSync('git rev-parse --abbrev-ref HEAD', execOpts)
     .toString('utf8')
     .trim();
-  console.log({ headBefore, currentBranch });
 
   if (currentBranch !== 'master') {
     throw new Error(

--- a/src/e-check-for-updates.js
+++ b/src/e-check-for-updates.js
@@ -17,10 +17,9 @@ program
 
 try {
   console.log('Checking for build-tools updates');
-  const baseDir = path.resolve(__dirname, '..');
 
   const execOpts = {
-    cwd: baseDir,
+    cwd: path.resolve(__dirname, '..'),
   };
 
   const headBefore = cp
@@ -46,11 +45,7 @@ try {
     .toString('utf8')
     .trim();
   if (headBefore !== headAfter) {
-    console.log(
-      color.childExec('npx', ['yarn'], {
-        cwd: baseDir,
-      }),
-    );
+    console.log(color.childExec('npx', ['yarn'], execOpts));
     cp.execSync('npx yarn', execOpts);
     console.log('Updated to Latest Build Tools');
   } else {


### PR DESCRIPTION
Follow-up to 3c5d043a2956f41c704023609cef2971f789ce04 and 7cd0f88d6f4e65826547015690036547a1e612c0 to ensure that `git` is called from the correct directory.