### PR TITLE
docs: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Once they're installed, clone a copy of `build-tools`
 and add it to your path:
 
 ```sh
-# get build-tools:
-git clone https://github.com/electron/build-tools.git
-cd build-tools
-yarn install
+# Install build-tools package globally:
+npm i -g @electron/build-tools
 
 # then, if on Darwin / Linux:
 export PATH="$PATH:$PWD/src"


### PR DESCRIPTION
Update the README for the new [installer](https://github.com/electron/build-tools-installer).

cc @MarshallOfSound 