### PR TITLE
feat: add goma hooks that can be invoked by CI

### DIFF
--- a/src/e
+++ b/src/e
@@ -137,10 +137,7 @@ program
 program
   .command('update-goma')
   .description('Ensure a fresh copy of Goma is installed')
-  .action(() => {
-    const checksum = goma.downloadAndPrepare();
-    console.log(`goma checksum: ${checksum}`);
-  });
+  .action(() => console.log(`goma checksum: ${goma.downloadAndPrepare()}`));
 
 program
   .command('depot-tools')

--- a/src/e
+++ b/src/e
@@ -135,6 +135,14 @@ program
   .command('check-for-updates', 'Check for build-tools updates');
 
 program
+  .command('update-goma')
+  .description('Ensure a fresh copy of Goma is installed')
+  .action(() => {
+    const checksum = goma.downloadAndPrepare();
+    console.log(`goma checksum: ${checksum}`);
+  });
+
+program
   .command('depot-tools')
   .alias('d')
   .description('Run a command from the depot-tools directory with the correct configuration')

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -178,12 +178,12 @@ program
 
 program
   .command('gomadir')
-  .description('path to goma directory')
+  .description('Path of the goma directory')
   .action(() => console.log(goma.dir));
 
 program
-  .command('goma-gn-file')
-  .description('path to goma.gn file')
+  .command('gomagn')
+  .description('Path of the goma.gn file')
   .action(() => console.log(goma.gnFilePath));
 
 program.parse(process.argv);

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -176,6 +176,16 @@ program
     }
   });
 
+program
+  .command('gomadir')
+  .description('path to goma directory')
+  .action(() => console.log(goma.dir));
+
+program
+  .command('goma-gn-file')
+  .description('path to goma.gn file')
+  .action(() => console.log(goma.gnFilePath));
+
 program.parse(process.argv);
 
 if (process.argv.length < 3) {

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -33,7 +33,7 @@ function downloadAndPrepareGoma() {
     fs.readFileSync(gomaShaFile, 'utf8') === sha &&
     !process.env.ELECTRON_FORGE_GOMA_REDOWNLOAD
   )
-    return;
+    return sha;
 
   const filename = {
     darwin: 'goma-mac.tgz',
@@ -82,6 +82,7 @@ function downloadAndPrepareGoma() {
   }
   rimraf.sync(tmpDownload);
   fs.writeFileSync(gomaShaFile, sha);
+  return sha;
 }
 
 function gomaIsAuthenticated() {
@@ -108,7 +109,10 @@ function authenticateGoma() {
 
   if (!gomaIsAuthenticated()) {
     console.log(color.childExec('goma_auth.py', ['login'], { cwd: gomaDir }));
-    childProcess.execFileSync('python', ['goma_auth.py', 'login'], { cwd: gomaDir, stdio: 'inherit' });
+    childProcess.execFileSync('python', ['goma_auth.py', 'login'], {
+      cwd: gomaDir,
+      stdio: 'inherit',
+    });
   }
 }
 


### PR DESCRIPTION
Follows up https://github.com/electron/electron/pull/22784 discussion: we want CI to be able to use build-tools' goma utils in a way that won't break if `utils/goma.js` ever gets refactored. So this PR adds three new commands for CI to use:

* `e show gomadir` *(prints goma.dir)*
* `e show gomagn` *(prints goma.gnFilePath)*
* `e update-goma` *(runs goma.downloadAndPrepare())*

In addition, `goma.downloadAndPrepare()` now returns a checksum string on success so that `e update-goma` has something to log on success. This isn't essential -- the exit code already shows success/failure -- but is visually nice.

CC @jkleinsc @MarshallOfSound 