### PR TITLE
feat: inherit current config

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,9 @@ Valid patch directories can include:
 If you want your shell sessions to each have different active configs, try this in your `~/.profile` or `~/.zshrc` or `~/.bashrc`:
 
 ```sh
-export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+if [[ -z "${EVM_CURRENT_FILE}" ]]; then
+  export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+fi
 ```
 
 This will create per-shell temporary files in which he active config file can be changed with `e use`.

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -12,7 +12,10 @@ const configRoot = process.env.EVM_CONFIG || path.resolve(__dirname, '..', 'conf
 
 // If you want your shell sessions to each have different active configs,
 // try this in your ~/.profile or ~/.zshrc or ~/.bashrc:
-// export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+//
+// if [[ -z "${EVM_CURRENT_FILE}" ]]; then
+//   export EVM_CURRENT_FILE="$(mktemp --tmpdir evm-current.XXXXXXXX.txt)"
+// fi
 const currentFiles = _.compact([
   process.env.EVM_CURRENT_FILE,
   path.resolve(configRoot, 'evm-current.txt'),


### PR DESCRIPTION
Change the recommendation on when to set `EVM_CURRENT_FILE` in the startup bashrc/zshrc scripts: only set `EVM_CURRENT_FILE` if it's not already set.

Most of the time this change won't have any affect.

However it makes life nicer if you're hacking on multiple Electron versions at the same time and want new shells that you create (e.g. new tabs in a terminal) to inherit the right version. By inheriting the `EVM_CURRENT_FILE` environment variable, new shells will be synced to their parent's version.