### PR TITLE
docs: load-xcode is run automatically nowadays

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ You can run a new Electron build with this command:
 
 ```sh
 # The 'Hello, World!' of build-tools: get and build `master`
-
-# On macOS if you aren't sure you have the right SDK version you should run
-# Also on macOS if you are using Goma this is a _requirement_
-e load-xcode
-
 # Choose the directory where Electron's source and build files will reside.
 # You can specify any path you like; this command defaults to ~/projects/electron.
 # If you're going to use multiple branches, you may want something like:


### PR DESCRIPTION
As in title, this command is not required