### PR TITLE
feat: add "e open <pull | sha>"

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,16 @@ $ cd `e show src base` && pwd
 $ ripgrep --t h TakeHeapSnapshot `e show src`
 ```
 
+### `e open <commit | issue | PR>`
+
+Opens the GitHub page for the specified commit, pull request, or issue.
+
+For example, `e open 0920d01` will find the commit with an abbreviated
+sha1 of `0920d01`, see that it's associated with pull request #23450,
+and open https://github.com/electron/electron/pull/23450 in your browser.
+Since you can pass in a pull request or issue number as well,
+`e open 23450` would have the same effect.
+
 ### `e patches [patch-dir]`
 
 Exports patches to the desired patch folder in Electron source tree.

--- a/src/e
+++ b/src/e
@@ -132,6 +132,7 @@ program
   .command('test [specRunnerArgs...]', `Run Electron's spec runner`)
   .command('pr [options]', 'Open a GitHub URL where you can PR your changes')
   .command('patches <basename>', 'Refresh the patches in $root/src/electron/patches/$basename')
+  .command('open <sha1|PR#>', 'Open a GitHub URL for the given commit hash / pull # / issue #')
   .command(
     'load-xcode',
     'Loads required versions of Xcode and the macOS SDK and symlinks them.  This may require sudo',

--- a/src/e-open.js
+++ b/src/e-open.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+const cp = require('child_process');
+const got = require('got');
+const path = require('path');
+const program = require('commander');
+
+const evmConfig = require('./evm-config.js');
+const { color } = require('./utils/logging');
+
+// 'feat: added foo (#1234)' --> 1234
+function getPullNumberFromSubject(subject) {
+  const pullNumberRegex = /^.*\s\(#(\d+)\)$/;
+  const match = subject.match(pullNumberRegex);
+  return match ? Number.parseInt(match[1]) : null;
+}
+
+// abbrev-sha1 --> { pullNumber, sha1 }
+function getCommitInfo(object) {
+  let pullNumber = null;
+  let sha1 = null;
+
+  const cmd = 'git';
+  const args = ['show', '--no-patch', '--pretty=format:%H%n%s', object];
+  const opts = {
+    cwd: path.resolve(evmConfig.current().root, 'src', 'electron'),
+    encoding: 'utf8',
+  };
+
+  const result = cp.spawnSync(cmd, args, opts);
+  if (result.status === 0) {
+    const lines = result.stdout.split('\n');
+    sha1 = lines[0];
+    pullNumber = getPullNumberFromSubject(lines[1]);
+  }
+
+  return { pullNumber, sha1 };
+}
+
+// ask GitHub for a commit's pull request URLs
+async function getPullURLsFromGitHub(sha1) {
+  const ret = [];
+
+  const opts = {
+    url: `https://api.github.com/repos/electron/electron/commits/${sha1}/pulls`,
+    responseType: 'json',
+    headers: {
+      // https://developer.github.com/changes/2019-04-11-pulls-branches-for-commit/
+      Accept: 'application/vnd.github.groot-preview+json',
+    },
+  };
+  try {
+    const response = await got(opts); // find the commit's PRs
+    if (response.statusCode !== 200) {
+      throw new Error(`${opts.url} got ${response.headers.status}`);
+    }
+    ret.push(...(response.body || []).map(pull => pull.html_url).filter(url => !!url));
+  } catch (error) {
+    console.log(color.err, error);
+  }
+
+  return ret;
+}
+
+// get the pull request URLs for a git object or pull number
+async function getPullURLs(ref) {
+  const { pullNumber, sha1 } = getCommitInfo(ref);
+  const makeURL = num => `https://github.com/electron/electron/pull/${num}`;
+
+  if (pullNumber) {
+    return [makeURL(pullNumber)];
+  }
+
+  if (sha1) {
+    return await getPullURLsFromGitHub(sha1);
+  }
+
+  const parsed = Number.parseInt(ref);
+  if (Number.isSafeInteger(parsed)) {
+    return [makeURL(parsed)];
+  }
+
+  console.log(`${color.err} ${color.cmd(object)} is not a git object or pull request number`);
+  return [];
+}
+
+async function doOpen(opts) {
+  const urls = await getPullURLs(opts.object);
+
+  if (urls.length === 0) {
+    console.log(`${color.err} No PRs found for ${opts.object}`);
+    return;
+  }
+
+  const open = require('open');
+  for (const url of urls) {
+    if (opts.print) {
+      console.log(url);
+    } else {
+      open(url);
+    }
+  }
+}
+
+let name;
+let options;
+
+program
+  .arguments('<name>')
+  .description('Create a new build configuration')
+  .option('--print', 'Print the URL instead of opening it', false)
+  .action((name_in, options_in) => {
+    name = name_in;
+    options = options_in;
+  })
+  .parse(process.argv);
+
+doOpen({ object: name, print: options.print });


### PR DESCRIPTION
This is a feature I've been using for awhile as a bash script and thought it might be useful to other people working on the codebase.

Basically it's a quick helper to open the PR page from a commit's abbreviated sha1.

For example, `e open 0920d01` will find the commit with an abbreviated sha1 of `0920d01`, see that it's associated with pull request #23450, and open https://github.com/electron/electron/pull/23450 in your browser. Since you can pass in a pull request or issue number as well, `e open 23450` would do the same thing.
