### PR TITLE
chore: do not pass --ignore_locks to gclient sync.

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -30,15 +30,7 @@ function runGClientSync(config, syncArgs) {
   depot.ensure();
 
   const exec = 'python';
-  const args = [
-    'gclient.py',
-    'sync',
-    '--with_branch_heads',
-    '--with_tags',
-    '-vv',
-    '--ignore_locks',
-    ...syncArgs,
-  ];
+  const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', '-vv', ...syncArgs];
   const opts = {
     cwd: srcdir,
   };


### PR DESCRIPTION
Silences a warning that began @ [14a83ae](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/14a83aec5603e47208a4a41c8c085a1991d33d47):

> Warning: ignore_locks is no longer used. Please remove its usage.