### PR TITLE
fix: re-initializing the same directory should just sync

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -145,10 +145,19 @@ try {
 
   checkPlatformDependencies();
 
+  const config = createConfig(options);
+
   // make sure the config name is new
   const filename = evmConfig.pathOf(name);
   if (!options.force && fs.existsSync(filename)) {
-    throw Error(`Build config ${color.config(name)} already exists! (${color.path(filename)})`);
+    const existing = evmConfig.fetchByName(name);
+    if (existing.root !== config.root) {
+      throw Error(
+        `Build config ${color.config(
+          name,
+        )} already exists and points at a different root folder! (${color.path(filename)})`,
+      );
+    }
   }
 
   // Make sure the goma options are valid
@@ -161,7 +170,6 @@ try {
   }
 
   // save the new config
-  const config = createConfig(options);
   ensureRoot(config);
   evmConfig.save(name, config);
   console.log(`New build config ${color.config(name)} created in ${color.path(filename)}`);

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -188,4 +188,5 @@ module.exports = {
   pathOf,
   save,
   setCurrent,
+  fetchByName: name => sanitizeConfig(loadConfigFileRaw(name)),
 };


### PR DESCRIPTION
Fixes #150 

If we run `init` with a config name that already exists, just let it fall through to sync if the config that already exists also points at the currently targeted "root" directory.