### PR TITLE
feat: add "e patches all" option

### DIFF
--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -50,7 +50,9 @@ function exportPatches(target) {
 }
 
 program
-  .arguments('<basename-or-all>')
-  .description('Refresh all patches,  or the patches in $root/src/electron/patches/$basename')
+  .arguments('<target>')
+  .description(
+    "Refresh all patches if 'all' is specified; otherwise, refresh patches in $root/src/electron/patches/$target",
+  )
   .action(exportPatches)
   .parse(process.argv);


### PR DESCRIPTION
Real straightfoward, what this patch does is add an `e patches all` command which invokes `src/electron/script/export_all_patches.py` from the right directory and with the right config file.