### PR TITLE
fix: do not kill the build on cache-only mode if the server dies

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -60,7 +60,7 @@ function runNinja(config, target, ninjaArgs) {
       }
     }
 
-    goma.ensure();
+    goma.ensure(config);
     if (!ninjaArgs.includes('-j') && !ninjaArgs.find(arg => /^-j[0-9]+$/.test(arg.trim()))) {
       ninjaArgs.push('-j', process.platform === 'darwin' ? 50 : 200);
     }

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -157,7 +157,11 @@ program
   .action(() => {
     try {
       const config = evmConfig.current();
-      const options = { env: { ...process.env, ...config.env }, stdio: 'inherit', cwd: goma.dir };
+      const options = {
+        env: { ...process.env, ...config.env, ...goma.env(config) },
+        stdio: 'inherit',
+        cwd: goma.dir,
+      };
       childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
     } catch (e) {
       fatal(e);

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -63,6 +63,8 @@ function depotOpts(config, opts = {}) {
       'b1bdbc45421e4e0ff0584c4dbe583e93b046a411',
     ...config.env,
     ...opts.env,
+    // Circular reference so we have to delay load
+    ...require('./goma').env(config),
   };
 
   // put depot tools at the front of the path

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -124,9 +124,24 @@ function authenticateGoma(config) {
   }
 }
 
-function ensureGomaStart() {
+function ensureGomaStart(config) {
   console.log(color.childExec('goma_ctl.py', ['ensure_start'], { cwd: gomaDir }));
-  childProcess.execFileSync('python', ['goma_ctl.py', 'ensure_start'], { cwd: gomaDir });
+  childProcess.execFileSync('python', ['goma_ctl.py', 'ensure_start'], {
+    cwd: gomaDir,
+    env: {
+      ...process.env,
+      ...gomaEnv(config),
+    },
+  });
+}
+
+function gomaEnv(config) {
+  if (config.goma === 'cache-only') {
+    return {
+      GOMA_FALLBACK_ON_AUTH_FAILURE: 'true',
+    };
+  }
+  return {};
 }
 
 module.exports = {
@@ -136,4 +151,5 @@ module.exports = {
   dir: gomaDir,
   downloadAndPrepare: downloadAndPrepareGoma,
   gnFilePath: gomaGnFile,
+  env: gomaEnv,
 };


### PR DESCRIPTION
I hope this fixes an issue where the function would randomly return a not-authed error instead of a 200 cache-miss response.  Until we figure out why the not-authed responses arrive this should fix the issue by making goma not self-kill on a 401.