### PR TITLE
perf: make e build actually spawn the build slightly faster by optimizing goma checks

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -57,6 +57,8 @@ function runNinja(config, target, ninjaArgs) {
           );
           process.exit(status);
         }
+
+        goma.recordGomaLoginTime();
       }
     }
 


### PR DESCRIPTION
This makes some significantly faster happy paths in the `goma` checks we do before spawning `ninja`.  At least on my machine this makes the `ninja` command actually start several seconds sooner (tiny in the big picture but it was annoying watching it sit there every time)