### PR TITLE
feat: add remove config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains helper/wrapper scripts to make building Electron easier
 ## Installation
 
 A handful of prerequisites, such as git, python, and npm, are
-required for building Electron itself; these can be found in 
+required for building Electron itself; these can be found in
 [Platform Prerequisites][platform-prerequisites]. `npm` can be used
 with `build-tools` itself as well, but we've configured it to run
 with `yarn`, so we also recommend you [install it to your system](https://yarnpkg.com/lang/en/docs/install/).
@@ -17,8 +17,8 @@ Windows if you install them, or use built-in tools like Windows'
 
 Please note that `build-tools` (due to nested dependencies) might not work properly in powershell, please use `cmd` on Windows for optimum results.
 
-```sh	
-# Install build-tools package globally:	
+```sh
+# Install build-tools package globally:
 npm i -g @electron/build-tools
 ```
 
@@ -315,6 +315,10 @@ $ cd `e show src base` && pwd
 
 $ ripgrep --t h TakeHeapSnapshot `e show src`
 ```
+
+### `e remove <name>`
+
+`e remove|rm <name>` removes a build config from the list.
 
 ### `e open <commit | issue | PR>`
 

--- a/src/e
+++ b/src/e
@@ -128,6 +128,19 @@ program
   });
 
 program
+  .command('remove <name>')
+  .alias('rm')
+  .description('Remove build config <name> from list')
+  .action(name => {
+    try {
+      evmConfig.remove(name);
+      console.log(`Removed config ${color.config(name)}`);
+    } catch (e) {
+      fatal(e);
+    }
+  });
+
+program
   .command('show <subcommand>', 'Show info about the current build config')
   .command('test [specRunnerArgs...]', `Run Electron's spec runner`)
   .command('pr [options]', 'Open a GitHub URL where you can PR your changes')

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -203,6 +203,8 @@ function sanitizeConfig(config) {
 }
 
 function remove(name) {
+  testConfigExists(name);
+
   let currentConfigName;
   try {
     currentConfigName = currentName();
@@ -213,7 +215,6 @@ function remove(name) {
     throw Error(`Config is currently in use`);
   }
 
-  testConfigExists(name);
   const filename = pathOf(name);
   try {
     return fs.unlinkSync(filename);

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -39,7 +39,7 @@ function filenameToConfigName(filename) {
   return match ? match[1] : null;
 }
 
-function ensureConfigExists(name) {
+function testConfigExists(name) {
   if (!fs.existsSync(pathOf(name))) {
     throw Error(
       `Build config ${color.config(name)} not found. (Tried ${buildPathCandidates(name)
@@ -58,7 +58,7 @@ function save(name, o) {
 }
 
 function setCurrent(name) {
-  ensureConfigExists(name);
+  testConfigExists(name);
   try {
     currentFiles.forEach(filename => fs.writeFileSync(filename, `${name}\n`));
   } catch (e) {
@@ -206,14 +206,14 @@ function remove(name) {
   let currentConfigName;
   try {
     currentConfigName = currentName();
-  } catch (_) {
+  } catch {
     currentConfigName = null;
   }
   if (currentConfigName && currentConfigName === name) {
     throw Error(`Config is currently in use`);
   }
 
-  ensureConfigExists(name);
+  testConfigExists(name);
   const filename = pathOf(name);
   try {
     return fs.unlinkSync(filename);

--- a/tests/e-remove-spec.js
+++ b/tests/e-remove-spec.js
@@ -1,0 +1,75 @@
+const path = require('path');
+const createSandbox = require('./sandbox');
+
+describe('e-show', () => {
+  let sandbox;
+  let root;
+  let name;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    root = path.join(sandbox.tmpdir, sandbox.randomString());
+    name = sandbox.randomString();
+  });
+
+  afterEach(() => {
+    sandbox.cleanup();
+  });
+
+  it(`fails if a build configuration name doesn't exist or is not specified`, () => {
+    const result = sandbox
+      .eRemoveRunner()
+      .name(name)
+      .run();
+    expect(result.exitCode).toStrictEqual(1);
+    expect(result.stderr).toEqual(
+      expect.stringContaining('ERR') && expect.stringContaining('not found'),
+    );
+  });
+
+  it('fails if trying to remove a configuration that is currently in use', () => {
+    const configNameToRemove = 'remove-me';
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(name)
+      .run();
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(configNameToRemove)
+      .run();
+
+    const result = sandbox
+      .eRemoveRunner()
+      .name(configNameToRemove)
+      .run();
+    expect(result.exitCode).toStrictEqual(1);
+    expect(result.stderr).toEqual(
+      expect.stringContaining('ERR') && expect.stringContaining('in use'),
+    );
+  });
+
+  it('removes the specified configuration from our list', () => {
+    const configNameToRemove = 'remove-me';
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(configNameToRemove)
+      .run();
+
+    // Create secondary config to ensure first one is not in use.
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(name)
+      .run();
+
+    const result = sandbox
+      .eRemoveRunner()
+      .name(configNameToRemove)
+      .run();
+    expect(result.exitCode).toStrictEqual(0);
+    expect(result.stdout.toLowerCase()).toEqual(expect.stringContaining('removed'));
+  });
+});

--- a/tests/e-remove-spec.js
+++ b/tests/e-remove-spec.js
@@ -32,11 +32,6 @@ describe('e-show', () => {
     sandbox
       .eInitRunner()
       .root(root)
-      .name(name)
-      .run();
-    sandbox
-      .eInitRunner()
-      .root(root)
       .name(configNameToRemove)
       .run();
 

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -200,6 +200,27 @@ function eSyncRunner(execOptions) {
   return o;
 }
 
+// An `e remove` helper.
+// Example use: result = eRemoveRunner().name('test').run();
+// Returns { exitCode:number, stderr:string, stdout:string }
+function eRemoveRunner(execOptions) {
+  const stdio = 'pipe';
+  const cmd = path.resolve(buildToolsSrcDir, 'e');
+  const args = ['remove'];
+
+  const o = {
+    name: name => {
+      args.push(name);
+      return o;
+    },
+    run: () => {
+      return runSync([cmd, ...args], { ...execOptions, stdio });
+    },
+  };
+
+  return o;
+}
+
 function createSandbox() {
   // create new temporary directories
   const tmpdir = fs.mkdtempSync(path.join(process.cwd(), 'build-tools-spec-'));
@@ -230,6 +251,9 @@ function createSandbox() {
     },
     eSyncRunner: () => {
       return eSyncRunner(execOptions);
+    },
+    eRemoveRunner: () => {
+      return eRemoveRunner(execOptions);
     },
     randomString: () =>
       Math.random()


### PR DESCRIPTION
This PR adds a new command for removing old build configurations.

- `e remove|rm <name>`
- Prevents the removal of the current used build config.

resolves #182 