### PR TITLE
fix: if sanitizeConfig() makes changes, save them.

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -198,14 +198,30 @@ function sanitizeConfig(config) {
   return config;
 }
 
+function refreshConfig(name) {
+  const config = loadConfigFileRaw(name);
+
+  // if the config file contains outdated settings,
+  // replace it with updated settings
+  const serialize = item => yml.safeDump(item);
+  const oldval = serialize(config);
+  sanitizeConfig(config);
+  const newval = serialize(config);
+  if (oldval !== newval) {
+    save(name, config);
+  }
+
+  return config;
+}
+
 module.exports = {
-  current: () => sanitizeConfig(loadConfigFileRaw(currentName())),
+  current: () => refreshConfig(currentName()),
   currentName,
   execOf,
+  fetchByName: name => refreshConfig(name),
   names,
   outDir,
   pathOf,
   save,
   setCurrent,
-  fetchByName: name => sanitizeConfig(loadConfigFileRaw(name)),
 };


### PR DESCRIPTION
Minor annoyance fix: whenever sanitizeConfig() makes changes,  save those changes back to disk so that you don't keep getting the warnings until you manually edit (or remove) the offending config. :smile_cat: 

CC @codebytere @MarshallOfSound 