### PR TITLE
fix: point at the 'e' script's correct directory

### DIFF
--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -23,7 +23,7 @@ function ensureNodeHeaders(config) {
 
   if (needs_build) {
     const exec = process.execPath;
-    const args = [path.resolve(__dirname, 'e'), 'build', 'node:headers'];
+    const args = [path.resolve(__dirname, '..', 'e'), 'build', 'node:headers'];
     const opts = { stdio: 'inherit', encoding: 'utf8' };
     childProcess.execFileSync(exec, args, opts);
   }


### PR DESCRIPTION
Fixes #185. Thanks to @holmberd for reporting this and tracking down the source of the bug.