### PR TITLE
fix: run git command in correct working directory

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -14,7 +14,7 @@ function setRemotes(cwd, repo) {
     // First check that the fork remote exists.
     if (remote === 'fork') {
       const remotes = cp
-        .execSync('git remote')
+        .execSync('git remote', { cwd })
         .toString()
         .trim()
         .split('\n');


### PR DESCRIPTION
This should fix a small bug introduced [recently](https://github.com/electron/build-tools/commit/e198c2fef364ee3079c0919e235e18e15877ccf4#diff-6f5fbb459299d77d723c2fdfc7cdea4eR17) which was causing the `git remote` command to fail because it was not being run in the correct directory.