### PR TITLE
fix: resolve hang when starting goma

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -46,7 +46,7 @@ function downloadAndPrepareGoma(config) {
   if (fs.existsSync(path.resolve(gomaDir, 'goma_ctl.py'))) {
     depot.spawnSync(config, 'python', ['goma_ctl.py', 'stop'], {
       cwd: gomaDir,
-      stdio: 'ignore',
+      stdio: ['ignore'],
     });
   }
 
@@ -152,6 +152,7 @@ function ensureGomaStart(config) {
       ...process.env,
       ...gomaEnv(config),
     },
+    stdio: ['ignore'],
   });
 }
 


### PR DESCRIPTION
Fixes #91.

Now, don't ask me *why* it fixes it. 😄 Something to do with it hanging when stdio is actually attached. Didn't feel like spending more time debugging the root root cause once it was working.

@MarshallOfSound, I also have a branch that uses `start-goma.ps1` like you suggested, but that solution causes an extra window to appear briefly due to powershell, and that didn't seem ideal. Internally that script is also just using `goma_ctl.py ensure_start` so the extra layer of indirection didn't feel necessary one I resolved the hang.