### PR TITLE
chore: ignore third_party js when formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+third_party


### PR DESCRIPTION
Ignore `third_party` files when running `prettier:write`. Accidentally formatted all the minified files in `third_party/depot_tools/third_party/coverage/htmlfiles/` just now 😅 

cc @MarshallOfSound 