### PR TITLE
feat: enable running specific Electron binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,10 @@ target create "/Users/yourname/electron-gn/src/out/Testing/Electron.app/Contents
 
 ### `e test`
 
-`e test ` starts the local Electron build's test runner. Any extra args are passed
+`e test ` starts the local Electron build's test runner by default. Any extra args are passed
 along to the runner.
+
+You can also optionally specify an Electron executable to run by passing the path to a directory containing an Electron executable, as well as set a configuration option allowing you to specify a directory containing multiple Electron executable files by setting `config.electronBinaryDirectory` and then passing `--v=x.y.z`.
 
 To see all potential options for this command, run:
 
@@ -265,7 +267,7 @@ e test
 e test --runners=main
 ```
 
-Possible extra arguments to pass:
+Possible extra arguments to pass to the runner:
 * `--node` - Run Node.js' own tests with Electron in `RUN_AS_NODE` mode.
 * `--runners=<main|remote|native>` - The set of tests to run, can be either `main`, `remote`, or `native`.
 

--- a/README.md
+++ b/README.md
@@ -247,10 +247,8 @@ target create "/Users/yourname/electron-gn/src/out/Testing/Electron.app/Contents
 
 ### `e test`
 
-`e test ` starts the local Electron build's test runner by default. Any extra args are passed
+`e test ` starts the local Electron build's test runner. Any extra args are passed
 along to the runner.
-
-You can also optionally specify an Electron executable to run by passing the path to a directory containing an Electron executable, as well as set a configuration option allowing you to specify a directory containing multiple Electron executable files by setting `config.electronBinaryDirectory` and then passing `--v=x.y.z`.
 
 To see all potential options for this command, run:
 
@@ -270,6 +268,21 @@ e test --runners=main
 Possible extra arguments to pass to the runner:
 * `--node` - Run Node.js' own tests with Electron in `RUN_AS_NODE` mode.
 * `--runners=<main|remote|native>` - The set of tests to run, can be either `main`, `remote`, or `native`.
+
+### `e bin`
+
+`e bin` allows for starting an app with a specific Electron executable.
+
+You can specify the Electron executable to run by passing the path to a directory containing an Electron executable, or by setting a configuration option allowing you to specify a directory containing multiple Electron executable files by setting `config.electronBinaryDirectory` and then passing `--v=x.y.z`.
+
+Example:
+```sh
+# start an app with Electron version 1.2.3
+e bin --v=1.2.3 /path/to/app
+
+# start an app with the Electron executable at a specific path
+e bin --path=/path/to/electron/exec /path/to/app
+```
 
 ### `e show`
 

--- a/src/e
+++ b/src/e
@@ -63,6 +63,31 @@ program
   .alias('make');
 
 program
+  .command('start')
+  .alias('run')
+  .description('Run the Electron executable')
+  .allowUnknownOption()
+  .action(() => {
+    try {
+      const exec = evmConfig.execOf(evmConfig.current());
+      const args = program.rawArgs.slice(3);
+      const opts = { stdio: 'inherit' };
+      console.log(color.childExec(exec, args, opts));
+      childProcess.execFileSync(exec, args, opts);
+    } catch (e) {
+      fatal(e);
+    }
+  })
+  .on('--help', () => {
+    console.log('');
+    console.log('Examples:');
+    console.log('');
+    console.log('  $ e start .');
+    console.log('  $ e start /path/to/app');
+    console.log('  $ e start /path/to/app --js-flags');
+  });
+
+program
   .command('node')
   .description('Run the Electron build as if it were a Node.js executable')
   .allowUnknownOption()
@@ -118,7 +143,7 @@ program
 program
   .command('show <subcommand>', 'Show info about the current build config')
   .command('test [specRunnerArgs...]', `Run Electron's spec runner`)
-  .command('start [version] ', 'Run the Electron executable')
+  .command('bin <version|path>', 'Run a specific Electron executable')
   .command('pr [options]', 'Open a GitHub URL where you can PR your changes')
   .command('patches <basename>', 'Refresh the patches in $root/src/electron/patches/$basename')
   .command('open <sha1|PR#>', 'Open a GitHub URL for the given commit hash / pull # / issue #')

--- a/src/e
+++ b/src/e
@@ -63,31 +63,6 @@ program
   .alias('make');
 
 program
-  .command('start')
-  .alias('run')
-  .description('Run the Electron executable')
-  .allowUnknownOption()
-  .action(() => {
-    try {
-      const exec = evmConfig.execOf(evmConfig.current());
-      const args = program.rawArgs.slice(3);
-      const opts = { stdio: 'inherit' };
-      console.log(color.childExec(exec, args, opts));
-      childProcess.execFileSync(exec, args, opts);
-    } catch (e) {
-      fatal(e);
-    }
-  })
-  .on('--help', () => {
-    console.log('');
-    console.log('Examples:');
-    console.log('');
-    console.log('  $ e start .');
-    console.log('  $ e start /path/to/app');
-    console.log('  $ e start /path/to/app --js-flags');
-  });
-
-program
   .command('node')
   .description('Run the Electron build as if it were a Node.js executable')
   .allowUnknownOption()
@@ -143,6 +118,7 @@ program
 program
   .command('show <subcommand>', 'Show info about the current build config')
   .command('test [specRunnerArgs...]', `Run Electron's spec runner`)
+  .command('start [version] ', 'Run the Electron executable')
   .command('pr [options]', 'Open a GitHub URL where you can PR your changes')
   .command('patches <basename>', 'Refresh the patches in $root/src/electron/patches/$basename')
   .command('open <sha1|PR#>', 'Open a GitHub URL for the given commit hash / pull # / issue #')

--- a/src/e-bin.js
+++ b/src/e-bin.js
@@ -20,11 +20,9 @@ program
     console.log('');
     console.log('Examples:');
     console.log('');
-    console.log('  $ e start .');
-    console.log('  $ e start /path/to/app');
-    console.log('  $ e start --v=1.2.3 /path/to/app');
-    console.log('  $ e start --path=/path/to/electron/exec /path/to/app');
-    console.log('  $ e start /path/to/app --js-flags');
+    console.log('  $ e bin --v=1.2.3 /path/to/app');
+    console.log('  $ e bin --path=/path/to/electron/exec /path/to/app');
+    console.log('  $ e bin /path/to/app --js-flags');
   })
   .parse(process.argv);
 
@@ -65,8 +63,8 @@ try {
     args = program.rawArgs.slice(4);
     exec = path.join(program.path, evmConfig.electronExecPath());
   } else {
-    args = program.rawArgs.slice(2);
-    exec = evmConfig.execOf(config);
+    console.error(`${color.err} Must provide either a version or path.`);
+    process.exit(1);
   }
 
   const opts = { stdio: 'inherit' };

--- a/src/e-start.js
+++ b/src/e-start.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const childProcess = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const semver = require('semver');
+const program = require('commander');
+
+const evmConfig = require('./evm-config');
+const { color, fatal } = require('./utils/logging');
+
+program
+  .allowUnknownOption()
+  .option(
+    '--v <version>',
+    'A specific version binary of Electron to run the specified app with. Must have set the binary directory in the current config.',
+  )
+  .option('--path <path>', 'Path to an Electron executable')
+  .on('--help', () => {
+    console.log('');
+    console.log('Examples:');
+    console.log('');
+    console.log('  $ e start .');
+    console.log('  $ e start /path/to/app');
+    console.log('  $ e start --v=1.2.3 /path/to/app');
+    console.log('  $ e start --path=/path/to/electron/exec /path/to/app');
+    console.log('  $ e start /path/to/app --js-flags');
+  })
+  .parse(process.argv);
+
+try {
+  const config = evmConfig.current();
+
+  let exec;
+  let args;
+  if (program.v) {
+    const binDir = config.electronBinaryDirectory;
+    if (!binDir) {
+      console.error(`${color.err} config.electronBinaryDirectory not defined or not valid`);
+      process.exit(1);
+    } else if (!semver.valid(program.v)) {
+      console.error(`${color.err} ${color.cmd(program.v)} must be a valid semantic version`);
+      process.exit(1);
+    }
+
+    const binaryPath = path.resolve(binDir, program.v);
+    if (!fs.existsSync(binaryPath)) {
+      console.error(
+        `${color.err} Could not find Electron in ${color.path(
+          path.join(binDir, program.v),
+        )}. Please download it and try again.`,
+      );
+      process.exit(1);
+    }
+
+    args = program.rawArgs.slice(4);
+    exec = path.join(binaryPath, evmConfig.electronExecPath());
+  } else if (program.path) {
+    if (!fs.existsSync(program.path)) {
+      console.error(
+        `${color.err} ${color.path(program.path)} does not contain a valid Electron executable.`,
+      );
+      process.exit(1);
+    }
+    args = program.rawArgs.slice(4);
+    exec = path.join(program.path, evmConfig.electronExecPath());
+  } else {
+    args = program.rawArgs.slice(2);
+    exec = evmConfig.execOf(config);
+  }
+
+  const opts = { stdio: 'inherit' };
+  console.log(color.childExec(exec, args, opts));
+  childProcess.execFileSync(exec, args, opts);
+} catch (e) {
+  fatal(e);
+}

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -93,18 +93,22 @@ function outDir(config) {
   return path.resolve(config.root, 'src', 'out', config.gen.out);
 }
 
+function electronExecPath(execName = 'electron') {
+  switch (os.type()) {
+    case 'Linux':
+      return execName;
+    case 'Darwin':
+      const upperExecName = execName[0].toUpperCase() + execName.slice(1);
+      return path.join(`${upperExecName}.app`, 'Contents', 'MacOS', upperExecName);
+    default:
+      return `${execName}.exe`;
+  }
+}
+
 function execOf(config) {
   const execName = (config.execName || 'electron').toLowerCase();
   const builddir = outDir(config);
-  switch (os.type()) {
-    case 'Linux':
-      return path.resolve(builddir, execName);
-    case 'Darwin':
-      const upperExecName = execName[0].toUpperCase() + execName.slice(1);
-      return path.resolve(builddir, `${upperExecName}.app`, 'Contents', 'MacOS', upperExecName);
-    default:
-      return path.resolve(builddir, `${execName}.exe`);
-  }
+  return path.resolve(builddir, electronExecPath(execName));
 }
 
 function maybeExtendConfig(config) {
@@ -150,8 +154,6 @@ function sanitizeConfig(name, overwrite = false) {
   }
 
   if (config.origin) {
-    const oldConfig = color.config(util.inspect({ origin: config.origin }));
-
     config.remotes = {
       electron: {
         origin: config.origin.electron,
@@ -162,7 +164,7 @@ function sanitizeConfig(name, overwrite = false) {
     };
 
     delete config.origin;
-    changes.push(`replaced superceded 'origin' property with 'remotes' property`);
+    changes.push(`replaced superseded 'origin' property with 'remotes' property`);
   }
 
   if (
@@ -218,6 +220,7 @@ function remove(name) {
 module.exports = {
   current: () => sanitizeConfig(currentName()),
   currentName,
+  electronExecPath,
   execOf,
   fetchByName: name => sanitizeConfig(name),
   names,


### PR DESCRIPTION
This makes it such that one can run specific electron binaries against a fork of electron-quick-start or similar repros which can't, for example, be written with Fiddle. I've been doing this myself for a while, and figured that it would be a handy thing to build into `build-tools`.

<details>
<Summary>New corresponding evm.base.yml</Summary>

```yaml
root: /Users/codebytere/Developer/electron-gn
electronBinaryDirectory: '/Users/codebytere/Library/Application Support/Electron Fiddle/electron-bin'
remotes:
  electron:
    origin: https://github.com/electron/electron
  node:
    origin: https://github.com/nodejs/node
env:
  GIT_CACHE_PATH: /Users/codebytere/.git_cache
  CHROMIUM_BUILDTOOLS_PATH: /Users/codebytere/Developer/electron-gn/src/buildtools
```

</details>

cc @ckerr 