### PR TITLE
chore: use caching on GitHub workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-node-modules
+    - name: Install
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: yarn install
     - name: Lint
-      run: |
-        yarn install
-        yarn lint
+      run: yarn lint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: yarn install and test
-      run: |
-        yarn install
-        yarn test
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-node-modules
+    - name: Install
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: yarn install
+    - name: Test
+      run: yarn test


### PR DESCRIPTION
`yarn install` was taking nearly a full minute on the Windows CI builds. Cache `node_modules` based on the hash of `yarn.lock` and save all the times. Tested on my own fork including updating `yarn.lock` to observe the cache busting.