### PR TITLE
feat: add `e show depotdir`

### DIFF
--- a/src/e-show.js
+++ b/src/e-show.js
@@ -8,6 +8,7 @@ const program = require('commander');
 
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
+const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
 
 function gitStatus(config) {
@@ -81,6 +82,11 @@ program
       fatal(e);
     }
   });
+
+program
+  .command('depotdir')
+  .description('Path of the depot-tools directory')
+  .action(() => console.log(depot.path));
 
 program
   .command('env')


### PR DESCRIPTION
Does what it says on the tin:

```sh
$ e show depotdir
/home/charles/electron/build-tools/third_party/depot_tool
```

This sibling to `e show gomadir` is a small change, but is nice-to-have for cases where I have a one-off task for depot-tools and want to manually add it to my path.