### PR TITLE
chore: set divergent branch reconciliation strategy

### DIFF
--- a/src/e-check-for-updates.js
+++ b/src/e-check-for-updates.js
@@ -34,8 +34,8 @@ try {
     );
   }
 
-  console.log(color.childExec('git', ['pull'], execOpts));
-  cp.execSync('git pull', execOpts);
+  console.log(color.childExec('git', ['pull', '--rebase', '--autostash'], execOpts));
+  cp.execSync('git pull --rebase --autostash', execOpts);
   const headAfter = cp
     .execSync('git rev-parse --verify HEAD', execOpts)
     .toString('utf8')


### PR DESCRIPTION
Newer versions of git display the following:
```
Running "git pull" in /Users/codebytere/build-tools
warning: Pulling without specifying how to reconcile divergent branches is
discouraged. You can squelch this message by running one of the following
commands sometime before your next pull:

  git config pull.rebase false  # merge (the default strategy)
  git config pull.rebase true   # rebase
  git config pull.ff only       # fast-forward only

You can replace "git config" with "git config --global" to set a default
preference for all repositories. You can also pass --rebase, --no-rebase,
or --ff-only on the command line to override the configured default per
invocation.
```

this squelches the message by setting the strategy to rebase with autostash for minimal disruption.