### PR TITLE
fix: reassign const in e-show

### DIFF
--- a/src/e-show.js
+++ b/src/e-show.js
@@ -10,7 +10,6 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
-const depot = require('./utils/depot-tools');
 
 function gitStatus(config) {
   const exec = 'git';


### PR DESCRIPTION
Fix a regression that snuck in yesterday by trying to reassign the const variable `depot` in e-show.js