### PR TITLE
feat: add backport functionality to `e pr`

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -3,11 +3,55 @@
 const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const querystring = require('querystring');
 
+const got = require('got');
 const open = require('open');
 const program = require('commander');
 
 const evmConfig = require('./evm-config');
+const { color, fatal } = require('./utils/logging');
+
+// Adapted from https://github.com/electron/clerk
+function findNoteInPRBody(body) {
+  const onelineMatch = /(?:(?:\r?\n)|^)notes: (.+?)(?:(?:\r?\n)|$)/gi.exec(body);
+  const multilineMatch = /(?:(?:\r?\n)Notes:(?:\r?\n+)((?:\*.+(?:(?:\r?\n)|$))+))/gi.exec(body);
+
+  let notes = null;
+  if (onelineMatch && onelineMatch[1]) {
+    notes = onelineMatch[1];
+  } else if (multilineMatch && multilineMatch[1]) {
+    notes = multilineMatch[1];
+  }
+
+  if (notes) {
+    // Remove the default PR template.
+    notes = notes.replace(/<!--.*?-->/g, '');
+  }
+
+  return notes ? notes.trim() : notes;
+}
+
+async function getPullRequestNotes(pullNumber) {
+  let notes = null;
+
+  const opts = {
+    url: `https://api.github.com/repos/electron/electron/pulls/${pullNumber}`,
+    responseType: 'json',
+    throwHttpErrors: false,
+  };
+  try {
+    const response = await got(opts);
+    if (response.statusCode !== 200) {
+      fatal(`Could not find PR: ${opts.url} got ${response.headers.status}`);
+    }
+    notes = findNoteInPRBody(response.body.body);
+  } catch (error) {
+    console.log(color.err, error);
+  }
+
+  return notes;
+}
 
 function guessPRTarget(config) {
   const filename = path.resolve(config.root, 'src', 'electron', 'package.json');
@@ -64,6 +108,19 @@ function pullRequestSource(source) {
   return source;
 }
 
+async function createPR(source, target, backport = undefined) {
+  const repoBaseUrl = 'https://github.com/electron/electron';
+  const comparePath = `${target}...${pullRequestSource(source)}`;
+  const queryParams = { expand: 1 };
+
+  if (backport) {
+    const notes = (await getPullRequestNotes(backport)) || '';
+    queryParams.body = `Backport of #${backport}.\n\nSee that PR for details.\n\nNotes: ${notes}`;
+  }
+
+  return open(`${repoBaseUrl}/compare/${comparePath}?${querystring.stringify(queryParams)}`);
+}
+
 let defaultTarget;
 let defaultSource;
 try {
@@ -78,10 +135,7 @@ program
   .description('Open a GitHub URL where you can PR your changes')
   .option('-s, --source <source_branch>', 'Where the changes are coming from', defaultSource)
   .option('-t, --target <target_branch>', 'Where the changes are going to', defaultTarget)
+  .option('-b, --backport <pull_request>', 'Pull request being backported')
   .parse(process.argv);
 
-open(
-  `https://github.com/electron/electron/compare/${program.target}...${pullRequestSource(
-    program.source,
-  )}?expand=1`,
-);
+createPR(program.source, program.target, program.backport);


### PR DESCRIPTION
This is built on top of #222. ~~I'll rebase once (if) that gets merged, so leaving as draft for now.~~

Borrows [some code from electron/clerk](https://github.com/electron/clerk/blob/20f4ef1cb723ba84a1a6f3c2e90dd9b51f1d2ee3/src/note-utils.ts#L7-L26). I didn't see an easy way to share that code so opted for copy-and-paste.

~~Not sure what the feasible upper-limit is for injecting the release notes in the URL. I tested with PR 25064 and it could handle that 12 word sentence. I think for practical purposes it's probably fine.~~

EDIT: Remembered that Vuetify uses the same functionality for their issues (you create it on a separate site and it redirects to the GitHub issue with it filled out). Just tested it with two paragraphs of 'lorem ipsum' and that worked fine, so the notes length isn't a concern.