### PR TITLE
chore: run CI tests on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,16 @@
-name: Continous Integration
+name: Continuous Integration
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
-    name: Test pull requests
+    name: Test
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Only lint is running on push to `master` at the moment, running test as well might help catch a mix-up like #221 more quickly.