### PR TITLE
fix: e-pr when no upstream

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -32,12 +32,12 @@ function guessPRTarget(config) {
 }
 
 function guessPRSource(config) {
-  const command = 'git rev-parse --abbrev-ref --symbolic-full-name @{upstream}';
+  const command = 'git rev-parse --abbrev-ref HEAD';
+
   const cwd = path.resolve(config.root, 'src', 'electron');
   const options = { cwd, encoding: 'utf8' };
-  const branch = childProcess.execSync(command, options).trim();
 
-  return branch.startsWith('origin/') ? branch.slice(7) : branch;
+  return childProcess.execSync(command, options).trim();
 }
 
 function pullRequestSource(source) {
@@ -48,7 +48,7 @@ function pullRequestSource(source) {
 
   const config = evmConfig.current();
 
-  if (source.startsWith('fork/')) {
+  if (config.remotes.electron.fork) {
     const command = 'git remote get-url fork';
     const cwd = path.resolve(config.root, 'src', 'electron');
     const options = { cwd, encoding: 'utf8' };
@@ -56,7 +56,7 @@ function pullRequestSource(source) {
 
     for (const regex of regexes) {
       if (regex.test(remoteUrl)) {
-        return `${regex.exec(remoteUrl)[1]}:${source.slice(5)}`;
+        return `${regex.exec(remoteUrl)[1]}:${source}`;
       }
     }
   }


### PR DESCRIPTION
Refs https://github.com/electron/build-tools/commit/f61f22c57413d40cbf2eb2377c0cdbe3571ab33f.

it's possible that a user has no upstream configured for a given branch when backporting, and so we should continue to use `git rev-parse --abbrev-ref HEAD` to find the branch name. By unilaterally asking for a configured upstream, we see the following error:

```console
electron on git:no-artifacts-fail-release-11 ❯ e pr 11           10:48AM
fatal: no upstream configured for branch 'no-artifacts-fail-release-11'
/Users/codebytere/build-tools/src/e-pr.js:51
  if (source.startsWith('fork/')) {
             ^

TypeError: Cannot read property 'startsWith' of undefined
    at pullRequestSource (/Users/codebytere/build-tools/src/e-pr.js:51:14)
    at Object.<anonymous> (/Users/codebytere/build-tools/src/e-pr.js:84:71)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:941:32)
    at Function.Module._load (internal/modules/cjs/loader.js:782:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
```

Our goal is to determine whether we're on a fork, so instead we should switch on config data to determine whether to PR with a different remote url.

cc @MarshallOfSound @dsanders11  