### PR TITLE
fix: make invocation of git-export-patches Windows-friendly

### DIFF
--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -28,9 +28,10 @@ function exportPatches(target) {
         encoding: 'utf8',
       });
     } else if (targets[target]) {
+      const script = path.resolve(srcdir, 'electron', 'script', 'git-export-patches');
       childProcess.execFileSync(
-        path.resolve(srcdir, 'electron', 'script', 'git-export-patches'),
-        ['-o', path.resolve(srcdir, 'electron', 'patches', target)],
+        'python',
+        [script, '-o', path.resolve(srcdir, 'electron', 'patches', target)],
         { cwd: path.resolve(root, targets[target]), stdio: 'inherit', encoding: 'utf8' },
       );
     } else {


### PR DESCRIPTION
Windows won't run filenames with no extensions as a program. Usually you can add `.cmd` to make that work, like how `@electron/build-tools` sets up `build-tools`, but since it's just Python, use Python to run it. Didn't seem worthwhile to add the `.cmd` alias in the main repo... although that might help people trying to run it without `build-tools`. I'll defer to others on which repo this fix should go on.