### PR TITLE
chore: add JSON schema for config files

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -1,0 +1,126 @@
+{
+  "title": "JSON schema for EVM configuration files",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "defaultTarget": {
+      "description": "Default build target",
+      "type": "string",
+      "enum": [
+        "breakpad",
+        "chromedriver",
+        "electron",
+        "electron:dist",
+        "mksnapshot",
+        "node:headers"
+      ]
+    },
+    "goma": {
+      "description": "Goma mode to use",
+      "type": "string",
+      "enum": [
+        "cache-only",
+        "cluster",
+        "none"
+      ],
+      "default": "cache-only"
+    },
+    "root": {
+      "description": "Path of the top directory. Home of the .gclient file",
+      "type": "string",
+      "minLength": 1
+    },
+    "remotes": {
+      "description": "Remotes for Git checkouts",
+      "type": "object",
+      "properties": {
+        "electron": {
+          "description": "Remotes for the Electron repo",
+          "type": "object",
+          "properties": {
+            "fork": {
+              "description": "Fork remote",
+              "type": "string",
+              "format": "uri",
+              "minLength": 1
+            },
+            "origin": {
+              "description": "Origin remote",
+              "type": "string",
+              "format": "uri",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "origin"
+          ]
+        },
+        "node": {
+          "description": "Remotes for the Node repo",
+          "type": "object",
+          "properties": {
+            "origin": {
+              "description": "Origin remote",
+              "type": "string",
+              "format": "uri",
+              "minLength": 1
+            }
+          }
+        }
+      },
+      "required": [
+        "electron",
+        "node"
+      ]
+    },
+    "gen": {
+      "description": "Configuration for GN",
+      "type": "object",
+      "properties": {
+        "args": {
+          "description": "Extra arguments for GN",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "out": {
+          "description": "Output directory",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "args",
+        "out"
+      ]
+    },
+    "env": {
+      "description": "Environment variables set when building Electron",
+      "type": "object",
+      "properties": {
+        "GIT_CACHE_PATH": {
+          "description": "Path to use as git cache for gclient",
+          "type": "string",
+          "minLength": 1
+        },
+        "CHROMIUM_BUILDTOOLS_PATH": {
+          "description": "Path of Chromium buildtools in the checkout",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "CHROMIUM_BUILDTOOLS_PATH"
+      ]
+    }
+  },
+  "required": [
+    "goma",
+    "root",
+    "remotes",
+    "gen",
+    "env"
+  ]
+}


### PR DESCRIPTION
Any interest in adding this? I made it for use with my VS Code extension, where JSON schemas can be used to provide functionality when editing JSON files (see GIF below). It's always nice to have a spec for stuff like the config files. I should be able to make the extension load it from `.electron_build_tools`, so if it lives in this repo then everyone can benefit.

![evm-config-schema](https://user-images.githubusercontent.com/5820654/98905421-3ccdf600-2470-11eb-901d-9a7de009383f.gif)
