### PR TITLE
chore: invoke python2 explicitly when it's present

### DIFF
--- a/src/e
+++ b/src/e
@@ -187,7 +187,7 @@ program
       goma.downloadAndPrepare(evmConfig.current());
       cwd = goma.dir;
       args[0] = `${args[0]}.py`;
-      args.unshift(paths.python2);
+      args.unshift(paths.python);
     }
 
     const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {

--- a/src/e
+++ b/src/e
@@ -9,6 +9,7 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const paths = require('./utils/paths');
 const { refreshPathVariable } = require('./utils/refresh-path');
 
 // Refresh the PATH variable at the top of this shell so that retries in the same shell get the latest PATH variable
@@ -186,7 +187,7 @@ program
       goma.downloadAndPrepare(evmConfig.current());
       cwd = goma.dir;
       args[0] = `${args[0]}.py`;
-      args.unshift('python');
+      args.unshift(paths.python2);
     }
 
     const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -9,6 +9,7 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const paths = require('./utils/paths');
 
 function runGNGen(config) {
   depot.ensure();
@@ -41,7 +42,7 @@ function runNinja(config, target, useGoma, ninjaArgs) {
         console.log('Not Authenticated - Triggering Goma Login');
         const { status, error } = depot.spawnSync(
           evmConfig.current(),
-          'python',
+          paths.python2,
           ['goma_auth.py', 'login'],
           {
             cwd: goma.dir,

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -42,7 +42,7 @@ function runNinja(config, target, useGoma, ninjaArgs) {
         console.log('Not Authenticated - Triggering Goma Login');
         const { status, error } = depot.spawnSync(
           evmConfig.current(),
-          paths.python2,
+          paths.python,
           ['goma_auth.py', 'login'],
           {
             cwd: goma.dir,

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -11,6 +11,7 @@ const { color, fatal } = require('./utils/logging');
 const { resolvePath, ensureDir } = require('./utils/paths');
 const goma = require('./utils/goma');
 const depot = require('./utils/depot-tools');
+const paths = require('./utils/paths');
 const { checkGlobalGitConfig } = require('./utils/git');
 const { checkPlatformDependencies } = require('./utils/deps-check');
 
@@ -70,7 +71,7 @@ function createConfig(options) {
 function runGClientConfig(config) {
   const { root } = config;
   depot.ensure();
-  const exec = 'python';
+  const exec = paths.python2;
   const args = [
     'gclient.py',
     'config',

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -71,7 +71,7 @@ function createConfig(options) {
 function runGClientConfig(config) {
   const { root } = config;
   depot.ensure();
-  const exec = paths.python2;
+  const exec = paths.python;
   const args = [
     'gclient.py',
     'config',

--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -6,6 +6,7 @@ const program = require('commander');
 const childProcess = require('child_process');
 
 const evmConfig = require('./evm-config.js');
+const paths = require('./utils/paths');
 const { color, fatal } = require('./utils/logging');
 
 function exportPatches(target) {
@@ -22,7 +23,7 @@ function exportPatches(target) {
 
     if (target === 'all') {
       const script = path.resolve(srcdir, 'electron', 'script', 'export_all_patches.py');
-      childProcess.execFileSync('python', [script, patchesConfig], {
+      childProcess.execFileSync(paths.python2, [script, patchesConfig], {
         cwd: root,
         stdio: 'inherit',
         encoding: 'utf8',
@@ -30,7 +31,7 @@ function exportPatches(target) {
     } else if (targets[target]) {
       const script = path.resolve(srcdir, 'electron', 'script', 'git-export-patches');
       childProcess.execFileSync(
-        'python',
+        paths.python2,
         [script, '-o', path.resolve(srcdir, 'electron', 'patches', target)],
         { cwd: path.resolve(root, targets[target]), stdio: 'inherit', encoding: 'utf8' },
       );

--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -23,7 +23,7 @@ function exportPatches(target) {
 
     if (target === 'all') {
       const script = path.resolve(srcdir, 'electron', 'script', 'export_all_patches.py');
-      childProcess.execFileSync(paths.python2, [script, patchesConfig], {
+      childProcess.execFileSync(paths.python, [script, patchesConfig], {
         cwd: root,
         stdio: 'inherit',
         encoding: 'utf8',
@@ -31,7 +31,7 @@ function exportPatches(target) {
     } else if (targets[target]) {
       const script = path.resolve(srcdir, 'electron', 'script', 'git-export-patches');
       childProcess.execFileSync(
-        paths.python2,
+        paths.python,
         [script, '-o', path.resolve(srcdir, 'electron', 'patches', target)],
         { cwd: path.resolve(root, targets[target]), stdio: 'inherit', encoding: 'utf8' },
       );

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -186,7 +186,7 @@ program
         stdio: 'inherit',
         cwd: goma.dir,
       };
-      childProcess.execFileSync(paths.python2, ['goma_ctl.py', 'stat'], options);
+      childProcess.execFileSync(paths.python, ['goma_ctl.py', 'stat'], options);
     } catch (e) {
       fatal(e);
     }

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -10,6 +10,7 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const paths = require('./utils/paths');
 
 function gitStatus(config) {
   const exec = 'git';
@@ -185,7 +186,7 @@ program
         stdio: 'inherit',
         cwd: goma.dir,
       };
-      childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
+      childProcess.execFileSync(paths.python2, ['goma_ctl.py', 'stat'], options);
     } catch (e) {
       fatal(e);
     }

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -8,6 +8,7 @@ const evmConfig = require('./evm-config');
 const { fatal } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const depot = require('./utils/depot-tools');
+const paths = require('./utils/paths');
 
 function setRemotes(cwd, repo) {
   for (const remote in repo) {
@@ -41,7 +42,7 @@ function runGClientSync(config, syncArgs, syncOpts) {
 
   depot.ensure();
 
-  const exec = 'python';
+  const exec = paths.python2;
   const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', '-vv', ...syncArgs];
   const opts = {
     cwd: srcdir,

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -42,7 +42,7 @@ function runGClientSync(config, syncArgs, syncOpts) {
 
   depot.ensure();
 
-  const exec = paths.python2;
+  const exec = paths.python;
   const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', '-vv', ...syncArgs];
   const opts = {
     cwd: srcdir,

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -110,7 +110,7 @@ function depotSpawnSync(config, cmd, args, opts_in) {
 }
 
 function depotExecFileSync(config, exec, args, opts_in) {
-  if (exec === paths.python2 && !path.isAbsolute(args[0])) {
+  if (exec === paths.python && !path.isAbsolute(args[0])) {
     args[0] = path.resolve(DEPOT_TOOLS_DIR, args[0]);
   }
   const opts = depotOpts(config, opts_in);

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -5,6 +5,7 @@ const childProcess = require('child_process');
 const pathKey = require('path-key');
 
 const { color } = require('./logging');
+const paths = require('./paths');
 
 const defaultDepotPath = path.resolve(__dirname, '..', '..', 'third_party', 'depot_tools');
 const DEPOT_TOOLS_DIR = process.env.DEPOT_TOOLS_DIR || defaultDepotPath;
@@ -109,7 +110,7 @@ function depotSpawnSync(config, cmd, args, opts_in) {
 }
 
 function depotExecFileSync(config, exec, args, opts_in) {
-  if (exec === 'python' && !path.isAbsolute(args[0])) {
+  if (exec === paths.python2 && !path.isAbsolute(args[0])) {
     args[0] = path.resolve(DEPOT_TOOLS_DIR, args[0]);
   }
   const opts = depotOpts(config, opts_in);

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -45,7 +45,7 @@ function downloadAndPrepareGoma(config) {
   }[process.platform];
 
   if (fs.existsSync(path.resolve(gomaDir, 'goma_ctl.py'))) {
-    depot.spawnSync(config, paths.python2, ['goma_ctl.py', 'stop'], {
+    depot.spawnSync(config, paths.python, ['goma_ctl.py', 'stop'], {
       cwd: gomaDir,
       stdio: ['ignore'],
     });
@@ -103,7 +103,7 @@ function gomaIsAuthenticated() {
 
   let loggedInInfo;
   try {
-    loggedInInfo = childProcess.execFileSync(paths.python2, ['goma_auth.py', 'info'], {
+    loggedInInfo = childProcess.execFileSync(paths.python, ['goma_auth.py', 'info'], {
       cwd: gomaDir,
       stdio: ['ignore'],
     });
@@ -122,7 +122,7 @@ function authenticateGoma(config) {
 
   if (!gomaIsAuthenticated()) {
     console.log(color.childExec('goma_auth.py', ['login'], { cwd: gomaDir }));
-    childProcess.execFileSync(paths.python2, ['goma_auth.py', 'login'], {
+    childProcess.execFileSync(paths.python, ['goma_auth.py', 'login'], {
       cwd: gomaDir,
       stdio: 'inherit',
     });
@@ -147,7 +147,7 @@ function ensureGomaStart(config) {
   if (status === 0) return;
 
   console.log(color.childExec('goma_ctl.py', ['ensure_start'], { cwd: gomaDir }));
-  childProcess.execFileSync(paths.python2, ['goma_ctl.py', 'ensure_start'], {
+  childProcess.execFileSync(paths.python, ['goma_ctl.py', 'ensure_start'], {
     cwd: gomaDir,
     env: {
       ...process.env,

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -6,6 +6,7 @@ const rimraf = require('rimraf');
 const { unzipSync } = require('cross-zip');
 const { color, fatal } = require('./logging');
 const depot = require('./depot-tools');
+const paths = require('./paths');
 
 const gomaDir = path.resolve(__dirname, '..', '..', 'third_party', 'goma');
 const gomaGnFile = path.resolve(__dirname, '..', '..', 'third_party', 'goma.gn');
@@ -44,7 +45,7 @@ function downloadAndPrepareGoma(config) {
   }[process.platform];
 
   if (fs.existsSync(path.resolve(gomaDir, 'goma_ctl.py'))) {
-    depot.spawnSync(config, 'python', ['goma_ctl.py', 'stop'], {
+    depot.spawnSync(config, paths.python2, ['goma_ctl.py', 'stop'], {
       cwd: gomaDir,
       stdio: ['ignore'],
     });
@@ -102,7 +103,7 @@ function gomaIsAuthenticated() {
 
   let loggedInInfo;
   try {
-    loggedInInfo = childProcess.execFileSync('python', ['goma_auth.py', 'info'], {
+    loggedInInfo = childProcess.execFileSync(paths.python2, ['goma_auth.py', 'info'], {
       cwd: gomaDir,
       stdio: ['ignore'],
     });
@@ -121,7 +122,7 @@ function authenticateGoma(config) {
 
   if (!gomaIsAuthenticated()) {
     console.log(color.childExec('goma_auth.py', ['login'], { cwd: gomaDir }));
-    childProcess.execFileSync('python', ['goma_auth.py', 'login'], {
+    childProcess.execFileSync(paths.python2, ['goma_auth.py', 'login'], {
       cwd: gomaDir,
       stdio: 'inherit',
     });
@@ -146,7 +147,7 @@ function ensureGomaStart(config) {
   if (status === 0) return;
 
   console.log(color.childExec('goma_ctl.py', ['ensure_start'], { cwd: gomaDir }));
-  childProcess.execFileSync('python', ['goma_ctl.py', 'ensure_start'], {
+  childProcess.execFileSync(paths.python2, ['goma_ctl.py', 'ensure_start'], {
     cwd: gomaDir,
     env: {
       ...process.env,

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -20,6 +20,6 @@ function ensureDir(dir) {
 
 module.exports = {
   ensureDir,
-  python2: which.sync('python2') || which.sync('python'),
+  python: which.sync('python2') || which.sync('python'),
   resolvePath,
 };

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const which = require('which');
 const { color } = require('./logging');
 
 function resolvePath(p) {
@@ -18,6 +19,7 @@ function ensureDir(dir) {
 }
 
 module.exports = {
-  resolvePath,
   ensureDir,
+  python2: which.sync('python2') || which.sync('python'),
+  resolvePath,
 };


### PR DESCRIPTION
Fixes #244 by invoking `python2` explicitly when present; `python` otherwise.

A better solution would be to make the toolchain work on both 2 and 3. This PR is an interim fix because my system is broken Right Now and I want it to work :smile: 