### PR TITLE
feat: use lldb init script in `e debug`

### DIFF
--- a/src/e-debug.js
+++ b/src/e-debug.js
@@ -22,7 +22,12 @@ function run_gdb(config) {
 
 function run_lldb(config) {
   const electron = evmConfig.execOf(config);
-  const args = [electron];
+  const lldbinit = path.resolve(config.root, 'src', 'tools', 'lldb', 'lldbinit.py');
+  const args = [
+    '-O' /* run before any file loads */,
+    `command script import ${lldbinit}`,
+    electron,
+  ];
   childProcess.execFileSync('lldb', args, opts);
 }
 


### PR DESCRIPTION
Automatically run [chromium's `lldbinit.py` script](https://chromium.googlesource.com/chromium/src/+/master/docs/lldbinit.md) (also [bonus reading](https://www.electronjs.org/docs/development/debugging-instructions-macos)) when starting lldb with `e debug`, exactly like what is currently done for gdb.

This is a small QoL change to streamline using lldb. Currently it is expected you either create a `.lldbinit` file ✨ somewhere ✨ that you call `lldb` / `e debug` from (lldb looks in the cwd) containing `command script import /path/to/src/tools/lldb/lldbinit.py` or run it yourself in lldb or something else like that. This provides that little one-liner as an argument to `lldb` in the same way the `gdb` branch of the `e debug` command works.