### PR TITLE
feat: Use goma batch files in Windows

### DIFF
--- a/src/e
+++ b/src/e
@@ -199,8 +199,12 @@ program
     if (args[0] === 'goma_ctl' || args[0] === 'goma_auth') {
       goma.downloadAndPrepare(evmConfig.current());
       cwd = goma.dir;
-      args[0] = `${args[0]}.py`;
-      args.unshift('python');
+      if (process.platform === 'win32') {
+        args[0] = `${args[0]}.bat`;
+      } else {
+        args[0] = `${args[0]}.py`;
+        args.unshift('python');
+      }
     }
 
     const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -185,7 +185,11 @@ program
         stdio: 'inherit',
         cwd: goma.dir,
       };
-      childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
+      if (process.platform === 'win32') {
+        childProcess.execFileSync('goma_ctl.bat', ['stat'], options);
+      } else {
+        childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
+      }
     } catch (e) {
       fatal(e);
     }


### PR DESCRIPTION
This PR makes it so that the goma batch files are run instead of the goma python scripts on Windows.
The goma batch files contain logic to select the right Python to use (i.e. vpython, falling back to python if that's not available), and then running the goma python script with that Python. By using the right Python, Windows users can avoid a misleading error about pywin32 not being installed.