### PR TITLE
perf: set number of Goma subprocs equal to CPUs on Mac

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -162,7 +162,7 @@ function ensureGomaStart(config) {
     subprocs = {
       GOMA_MAX_SUBPROCS: cpus.toString(),
       GOMA_MAX_SUBPROCS_LOW: cpus.toString(),
-    }
+    };
   }
 
   console.log(color.childExec('goma_ctl.py', ['ensure_start'], { cwd: gomaDir }));

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -156,9 +156,9 @@ function ensureGomaStart(config) {
   if (status === 0) return;
 
   // Set number of subprocs to equal number of CPUs for MacOS
-  var subprocs = {};
+  let subprocs = {};
   if (process.platform === 'darwin') {
-    var cpus = os.cpus().length;
+    const cpus = os.cpus().length;
     subprocs = {
       GOMA_MAX_SUBPROCS: cpus.toString(),
       GOMA_MAX_SUBPROCS_LOW: cpus.toString(),


### PR DESCRIPTION
Mitigates #229 by setting the number of Goma subprocesses on Mac OS equal to the number of CPUs. Has no effect on other build platforms.

The default on Mac is to use 3/4 subprocesses which is very slow. With this change, using `e build -j 16` on a recent 16" MacBook resulted in ~3x compile time improvement. Current Goma args can be checked at `http://localhost:8088/flagz` with Goma started.
