### PR TITLE
fix: switch Windows to use vpython instead of batch files

### DIFF
--- a/src/e
+++ b/src/e
@@ -199,10 +199,10 @@ program
     if (args[0] === 'goma_ctl' || args[0] === 'goma_auth') {
       goma.downloadAndPrepare(evmConfig.current());
       cwd = goma.dir;
+      args[0] = `${args[0]}.py`;
       if (process.platform === 'win32') {
-        args[0] = `${args[0]}.bat`;
+        args.unshift('vpython');
       } else {
-        args[0] = `${args[0]}.py`;
         args.unshift('python');
       }
     }

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -38,12 +38,8 @@ function runNinja(config, target, useGoma, ninjaArgs) {
       const authenticated = goma.isAuthenticated(config.root);
       if (!authenticated) {
         console.log('Not Authenticated - Triggering Goma Login');
-        let program = 'python';
-        let programArgs = ['goma_auth.py', 'login'];
-        if (process.platform === 'win32') {
-          program = 'goma_auth.bat';
-          programArgs = ['login'];
-        }
+        const program = process.platform === 'win32' ? 'vpython' : 'python';
+        const programArgs = ['goma_auth.py', 'login'];
         const { status, error } = depot.spawnSync(evmConfig.current(), program, programArgs, {
           cwd: goma.dir,
           stdio: 'inherit',

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -186,7 +186,7 @@ program
         cwd: goma.dir,
       };
       if (process.platform === 'win32') {
-        childProcess.execFileSync('goma_ctl.bat', ['stat'], options);
+        childProcess.execFileSync('vpython', ['goma_ctl.py', 'stat'], options);
       } else {
         childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
       }


### PR DESCRIPTION
Fixes #258, fixes #252 

This PR changes the goma commands for Windows only. Now vpython (from depot_tools) runs the goma python files.
In PR #255, I changed it so that Windows ran batch files instead of python files, allowing `e build` to run smoothly on cmd. However, that change broke the building experience on git bash, and this solution makes it so that `e build` + goma login works on both git bash and cmd.