### PR TITLE
fix: add shell true to goma python/vpython calls

### DIFF
--- a/src/e
+++ b/src/e
@@ -210,6 +210,7 @@ program
     const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {
       cwd,
       stdio: 'inherit',
+      shell: true,
     });
     if (status !== 0) {
       console.error(

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -43,6 +43,7 @@ function runNinja(config, target, useGoma, ninjaArgs) {
         const { status, error } = depot.spawnSync(evmConfig.current(), program, programArgs, {
           cwd: goma.dir,
           stdio: 'inherit',
+          shell: true,
         });
 
         if (status !== 0) {

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -184,6 +184,7 @@ program
         env: { ...process.env, ...config.env, ...goma.env(config) },
         stdio: 'inherit',
         cwd: goma.dir,
+        shell: true,
       };
       if (process.platform === 'win32') {
         childProcess.execFileSync('vpython', ['goma_ctl.py', 'stat'], options);

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -54,7 +54,7 @@ function downloadAndPrepareGoma(config) {
     win32: 'goma-win.zip',
   }[process.platform];
 
-  const stopParams = { cwd: gomaDir, stdio: ['ignore'] };
+  const stopParams = { cwd: gomaDir, stdio: ['ignore'], shell: true };
   if (fs.existsSync(path.resolve(gomaDir, 'goma_ctl.py'))) {
     depot.spawnSync(config, pythonToUse, ['goma_ctl.py', 'stop'], stopParams);
   }
@@ -111,7 +111,7 @@ function gomaIsAuthenticated() {
 
   let loggedInInfo;
   try {
-    const infoParams = { cwd: gomaDir, stdio: ['ignore'] };
+    const infoParams = { cwd: gomaDir, stdio: ['ignore'], shell: true };
     loggedInInfo = childProcess.execFileSync(pythonToUse, ['goma_auth.py', 'info'], infoParams);
   } catch {
     return false;
@@ -127,7 +127,7 @@ function authenticateGoma(config) {
   downloadAndPrepareGoma(config);
 
   if (!gomaIsAuthenticated()) {
-    const loginParams = { cwd: gomaDir, stdio: 'inherit' };
+    const loginParams = { cwd: gomaDir, stdio: 'inherit', shell: true };
     console.log(color.childExec('goma_auth.py', ['login'], { cwd: gomaDir }));
     childProcess.execFileSync(pythonToUse, ['goma_auth.py', 'login'], loginParams);
     recordGomaLoginTime();
@@ -168,6 +168,7 @@ function ensureGomaStart(config) {
       ...subprocs,
     },
     stdio: ['ignore'],
+    shell: true,
   };
 
   console.log(color.childExec('goma_ctl.py', ['ensure_start'], { cwd: gomaDir }));


### PR DESCRIPTION
Though we should be using `vpython` on Windows (https://github.com/electron/build-tools/issues/252), it turns out that Windows has a hard time finding it unless we add `shell: true` to the spawn/exec opts.

Fixes https://github.com/electron/build-tools/issues/261