### PR TITLE
fix: revert PRs #260 and #255

### DIFF
--- a/src/e
+++ b/src/e
@@ -200,11 +200,7 @@ program
       goma.downloadAndPrepare(evmConfig.current());
       cwd = goma.dir;
       args[0] = `${args[0]}.py`;
-      if (process.platform === 'win32') {
-        args.unshift('vpython');
-      } else {
-        args.unshift('python');
-      }
+      args.unshift('python');
     }
 
     const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const program = require('commander');
 
@@ -11,7 +12,7 @@ const goma = require('./utils/goma');
 
 function runGNGen(config) {
   depot.ensure();
-  const gnBasename = process.platform === 'win32' ? 'gn.bat' : 'gn';
+  const gnBasename = os.platform() === 'win32' ? 'gn.bat' : 'gn';
   const gnPath = path.resolve(depot.path, gnBasename);
   const gnArgs = config.gen.args.join(' ');
   const execArgs = ['gen', `out/${config.gen.out}`, `--args=${gnArgs}`];
@@ -38,12 +39,15 @@ function runNinja(config, target, useGoma, ninjaArgs) {
       const authenticated = goma.isAuthenticated(config.root);
       if (!authenticated) {
         console.log('Not Authenticated - Triggering Goma Login');
-        const program = process.platform === 'win32' ? 'vpython' : 'python';
-        const programArgs = ['goma_auth.py', 'login'];
-        const { status, error } = depot.spawnSync(evmConfig.current(), program, programArgs, {
-          cwd: goma.dir,
-          stdio: 'inherit',
-        });
+        const { status, error } = depot.spawnSync(
+          evmConfig.current(),
+          'python',
+          ['goma_auth.py', 'login'],
+          {
+            cwd: goma.dir,
+            stdio: 'inherit',
+          },
+        );
 
         if (status !== 0) {
           console.error(
@@ -65,7 +69,7 @@ function runNinja(config, target, useGoma, ninjaArgs) {
   depot.ensure(config);
   ensureGNGen(config);
 
-  const exec = process.platform === 'win32' ? 'ninja.exe' : 'ninja';
+  const exec = os.platform() === 'win32' ? 'ninja.exe' : 'ninja';
   const args = [...ninjaArgs, target];
   const opts = {
     cwd: evmConfig.outDir(config),

--- a/src/e-show.js
+++ b/src/e-show.js
@@ -185,11 +185,7 @@ program
         stdio: 'inherit',
         cwd: goma.dir,
       };
-      if (process.platform === 'win32') {
-        childProcess.execFileSync('vpython', ['goma_ctl.py', 'stat'], options);
-      } else {
-        childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
-      }
+      childProcess.execFileSync('python', ['goma_ctl.py', 'stat'], options);
     } catch (e) {
       fatal(e);
     }


### PR DESCRIPTION
This PR reverts the previous attempts to get the goma commands to work on my Windows setup.
In other words, we are back to using `python goma*.py args`, and without `shell: true`.
See https://github.com/electron/build-tools/issues/261#issuecomment-793243309