### PR TITLE
chore: add new windows toolchain

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -54,7 +54,7 @@ function platformOpts() {
           '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
         GYP_MSVS_HASH_a687d8e2e4114d9015eb550e1b156af21381faac:
           'b1bdbc45421e4e0ff0584c4dbe583e93b046a411',
-        GYP_MSVS_HASH_20d5f2553f: 'b1bdbc45421e4e0ff0584c4dbe583e93b046a411',
+        GYP_MSVS_HASH_20d5f2553f: 'e146e01913',
       };
   }
 


### PR DESCRIPTION
The last chromium roll required a toolchain update but we hadn't built one yet so we used the old one which was causing build errors like:
`../../buildtools/third_party/libc++/trunk/include\__config(297,14): fatal error: 'winapifamily.h' file not found`
(as seen here: https://github.com/electron/build-tools/issues/264#issuecomment-794365022).

This PR updates buildtools to use a new toolchain.  Fixes #264