### PR TITLE
feat: add 'e cherry-pick' to auto-cherry-pick CLs into patches folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   "author": "Electron Authors",
   "license": "MIT",
   "dependencies": {
+    "@octokit/rest": "^18.5.2",
     "chalk": "^2.4.1",
     "command-exists": "^1.2.8",
     "commander": "^3.0.2",
     "cross-zip": "^3.0.0",
+    "debug": "^4.3.1",
     "got": "^10.2.2",
     "hasha": "^5.1.0",
     "js-yaml": "^3.13.1",

--- a/src/e
+++ b/src/e
@@ -156,7 +156,12 @@ program
     'Loads required versions of Xcode and the macOS SDK and symlinks them.  This may require sudo',
   )
   .command('auto-update', 'Check for build-tools updates or enable/disable automatic updates')
-  .alias('check-for-updates');
+  .alias('check-for-updates')
+  .command(
+    'cherry-pick <patch-url> <target-branch> [additionBranches...]',
+    'Opens a PR to electron/electron that backport the given CL into our patches folder',
+  )
+  .alias('auto-cherry-pick');
 
 program
   .command('update-goma')

--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+const d = require('debug')('build-tools:cherry-pick');
+const program = require('commander');
+const https = require('https');
+const { Octokit } = require('@octokit/rest');
+
+if (!process.env.GITHUB_TOKEN) {
+  console.error('Cannot run cherry-pick without $GITHUB_TOKEN');
+  process.exit(1);
+}
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+});
+
+function fetchBase64(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .request(url, res => {
+        let data = '';
+        res.setEncoding('ascii');
+        res.on('data', chunk => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve(Buffer.from(data, 'base64').toString('utf8'));
+        });
+        res.on('error', reject);
+      })
+      .end();
+  });
+}
+
+program
+  .arguments('<patch-url> <target-branch> [additionalBranches...]')
+  .option('--security', 'Whether this backport is for security reasons')
+  .description('Opens a PR to electron/electron that backport the given CL into our patches folder')
+  .action(async (patchUrlStr, targetBranch, additionalBranches) => {
+    try {
+      const {
+        data: { permissions },
+      } = await octokit.repos.get({
+        owner: 'electron',
+        repo: 'electron',
+      });
+      if (!permissions || !permissions.push) {
+        console.error(
+          'The supplied $GITHUB_TOKEN does not have write access to electron/electron, this script will bail now',
+        );
+        process.exit(1);
+      }
+
+      const targetBranches = [targetBranch, ...additionalBranches];
+
+      const gerritUrl = new URL(patchUrlStr);
+      if (
+        gerritUrl.host !== 'chromium-review.googlesource.com' &&
+        gerritUrl.host !== 'skia-review.googlesource.com'
+      ) {
+        console.error(
+          'Expected a gerrit URL (e.g. https://chromium-review.googlesource.com/c/v8/v8/+/2465830)',
+        );
+        process.exit(1);
+      }
+      const [, repo, number] = /^\/c\/(.+?)\/\+\/(\d+)/.exec(gerritUrl.pathname);
+
+      d(`fetching patch from gerrit`);
+      const changeId = `${repo}~${number}`;
+      const patchUrl = new URL(
+        `/changes/${encodeURIComponent(changeId)}/revisions/current/patch`,
+        gerritUrl,
+      );
+      const patch = await fetchBase64(patchUrl.toString());
+
+      const [, commitId] = /^From ([0-9a-f]+)/.exec(patch);
+
+      const patchDirName =
+        {
+          'chromium/src': 'chromium',
+          skia: 'skia',
+        }[repo] || repo.split('/')[1];
+
+      const shortCommit = commitId.substr(0, 12);
+      const patchName = `cherry-pick-${shortCommit}.patch`;
+      const patchPath = `patches/${patchDirName}`;
+      for (const target of targetBranches) {
+        const branchName = `cherry-pick/${target}/${patchDirName}/${shortCommit}`;
+        d(`fetching electron base branch info for ${target}`);
+        const {
+          data: {
+            commit: {
+              sha: targetSha,
+              commit: {
+                tree: { sha: targetBaseTreeSha },
+              },
+            },
+          },
+        } = await octokit.repos.getBranch({
+          owner: 'electron',
+          repo: 'electron',
+          branch: target,
+        });
+
+        d(`fetching base patch list`);
+        const { data: patchListData } = await octokit.repos
+          .getContent({
+            owner: 'electron',
+            repo: 'electron',
+            path: `${patchPath}/.patches`,
+            ref: targetSha,
+          })
+          .catch(err => {
+            console.log(
+              `NOTE: No patches existing for ${patchDirName} in ${target}, added a dir under patches/ but you'll need to manually edit patches/config.json`,
+            );
+            return {
+              data: null,
+            };
+          });
+        const patchList = patchListData
+          ? Buffer.from(patchListData.content, 'base64').toString('utf8')
+          : '';
+        const newPatchList = patchList + `${patchName}\n`;
+
+        d(`creating tree base_tree=${targetBaseTreeSha}`);
+        const { data: tree } = await octokit.git.createTree({
+          owner: 'electron',
+          repo: 'electron',
+          base_tree: targetBaseTreeSha,
+          tree: [
+            {
+              path: `${patchPath}/.patches`,
+              mode: '100644',
+              type: 'blob',
+              content: newPatchList,
+            },
+            {
+              path: `${patchPath}/${patchName}`,
+              mode: '100644',
+              type: 'blob',
+              content: patch,
+            },
+          ],
+        });
+
+        d(`creating commit tree=${tree.sha} parent=${targetSha}`);
+        const { data: commit } = await octokit.git.createCommit({
+          owner: 'electron',
+          repo: 'electron',
+          tree: tree.sha,
+          parents: [targetSha],
+          message: `chore: cherry-pick ${shortCommit} from ${patchDirName}`,
+        });
+
+        d(`creating ref`);
+        await octokit.git.createRef({
+          owner: 'electron',
+          repo: 'electron',
+          ref: `refs/heads/${branchName}`,
+          sha: commit.sha,
+        });
+
+        const bugNumber = (/^Bug: (.+)$/m.exec(patch) || [])[1];
+
+        const commitMessage = /Subject: \[PATCH\] (.+?)^---$/ms.exec(patch)[1];
+
+        d(`creating pr`);
+        const { data: pr } = await octokit.pulls.create({
+          owner: 'electron',
+          repo: 'electron',
+          head: `electron:${branchName}`,
+          base: target,
+          title: `chore: cherry-pick ${shortCommit} from ${patchDirName}`,
+          body: `${commitMessage}\n\nNotes: ${
+            bugNumber
+              ? program.security
+                ? `Security: backported fix for ${bugNumber}.`
+                : `Backported fix for ${bugNumber}.`
+              : `<!-- couldn't find bug number -->`
+          }`,
+          maintainer_can_modify: true,
+        });
+
+        d(`labelling pr`);
+        await octokit.issues.update({
+          owner: 'electron',
+          repo: 'electron',
+          issue_number: pr.number,
+          labels: [
+            target,
+            'backport-check-skip',
+            'semver/patch',
+            ...(program.security ? ['security 🔒'] : []),
+          ],
+        });
+
+        console.log(`Created cherry-pick PR to ${target}: ${pr.html_url}`);
+      }
+    } catch (err) {
+      console.error('Failed to cherry-pick:', err);
+      process.exit(1);
+    }
+  })
+  .parse(process.argv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,6 +293,107 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@octokit/auth-token@^2.4.4":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
+  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.2.3":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.4.0.tgz#b48aa27d755b339fe7550548b340dcc2b513b742"
+  integrity sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.4.12"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
+  integrity sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.5.8":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.1.tgz#f975486a46c94b7dbe58a0ca751935edc7e32cc9"
+  integrity sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.0.0.tgz#7da8d7d5a72d3282c1a3ff9f951c8133a707480d"
+  integrity sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==
+
+"@octokit/plugin-paginate-rest@^2.6.2":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz#f0f1792230805108762d87906fb02d573b9e070a"
+  integrity sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==
+  dependencies:
+    "@octokit/types" "^6.11.0"
+
+"@octokit/plugin-request-log@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
+  integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
+
+"@octokit/plugin-rest-endpoint-methods@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz#cf2cdeb24ea829c31688216a5b165010b61f9a98"
+  integrity sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==
+  dependencies:
+    "@octokit/types" "^6.13.0"
+    deprecation "^2.3.1"
+
+"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
+  integrity sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+  version "5.4.15"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
+  integrity sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^6.7.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.5.2":
+  version "18.5.2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.5.2.tgz#0369e554b7076e3749005147be94c661c7a5a74b"
+  integrity sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==
+  dependencies:
+    "@octokit/core" "^3.2.3"
+    "@octokit/plugin-paginate-rest" "^2.6.2"
+    "@octokit/plugin-request-log" "^1.0.2"
+    "@octokit/plugin-rest-endpoint-methods" "5.0.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.7.1":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.13.0.tgz#779e5b7566c8dde68f2f6273861dd2f0409480d0"
+  integrity sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==
+  dependencies:
+    "@octokit/openapi-types" "^6.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -688,6 +789,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+before-after-hook@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
+  integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1112,6 +1218,13 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1194,6 +1307,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 detect-libc@^1.0.2:
   version "1.0.3"
@@ -2023,6 +2141,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -2963,7 +3086,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -3018,6 +3141,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp@^6.1.0:
   version "6.1.0"
@@ -4421,6 +4549,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is an ad-hoc script that the security WG has been using for a while to backport security patches to older releases without having to do it by hand.  This generalizes the script a bit and makes it available for everyone easily through build-tools.

Example usage:
```bash
e cherry-pick https://chromium-review.googlesource.com/c/chromium/src/+/2823023 13-x-y
```