### PR TITLE
fix: error if backport number invalid

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -114,6 +114,10 @@ async function createPR(source, target, backport = undefined) {
   const queryParams = { expand: 1 };
 
   if (backport) {
+    if (!/^\d+$/.test(backport)) {
+      fatal(`${backport} is not a valid GitHub backport number - try again`);
+    }
+
     const notes = (await getPullRequestNotes(backport)) || '';
     queryParams.body = `Backport of #${backport}.\n\nSee that PR for details.\n\nNotes: ${notes}`;
   }


### PR DESCRIPTION
Improve UX slightly by throwing an error and stopping if the user accidentally passes an invalid backport number when running `e pr` with a backport.

<img width="675" alt="Screen Shot 2021-04-22 at 9 28 42 AM" src="https://user-images.githubusercontent.com/2036040/115673642-26946200-a34d-11eb-94c2-2bf9d7aea353.png">
