### PR TITLE
fix: missing notes when cherry-pick can't find bug

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -173,7 +173,7 @@ program
               ? program.security
                 ? `Security: backported fix for ${bugNumber}.`
                 : `Backported fix for ${bugNumber}.`
-              : `<!-- couldn't find bug number -->`
+              : `None <!-- couldn't find bug number -->`
           }`,
           maintainer_can_modify: true,
         });


### PR DESCRIPTION
Fixes failing check when bug can't be found in Chromium cherry-picks