### PR TITLE
fix: add new pattern to get crbug number for v8 backports

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -155,7 +155,8 @@ program
           sha: commit.sha,
         });
 
-        const bugNumber = (/^Bug: (.+)$/m.exec(patch) || [])[1];
+        const bugNumber =
+          (/^Bug: (.+)$/m.exec(patch) || [])[1] || (/^Bug= ?chromium:(.+)$/m.exec(patch) || [])[1];
 
         const commitMessage = /Subject: \[PATCH\] (.+?)^---$/ms.exec(patch)[1];
 


### PR DESCRIPTION
Format of `BUG=chromium:123` wasn't being parsed