### PR TITLE
fix: handle root dir existing with no .gclient

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -88,16 +88,18 @@ function runGClientConfig(config) {
 function ensureRoot(config) {
   const { root } = config;
 
-  if (!fs.existsSync(root)) {
-    ensureDir(root);
-    runGClientConfig(config);
-  } else if (fs.existsSync(path.resolve(root, '.gclient'))) {
+  ensureDir(root);
+
+  const hasOtherFiles = fs.readdirSync(root).some(file => file !== '.gclient');
+  if (hasOtherFiles) {
+    fatal(`Root ${color.path(root)} is not empty. Please choose a different root directory.`);
+  }
+
+  if (fs.existsSync(path.resolve(root, '.gclient'))) {
     console.info(`${color.info} Root ${color.path(root)} already exists.`);
-    console.info(`${color.info} (OK if you are sharing $root between multiple build configs)`);
-  } else if (fs.readdirSync(root).length > 0) {
-    fatal(
-      `Root ${color.path(root)} exists and is not empty. Please choose a different root directory.`,
-    );
+    console.info(`${color.info} (OK if you are sharing ${root} between multiple build configs)`);
+  } else {
+    runGClientConfig(config);
   }
 }
 

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -85,10 +85,10 @@ describe('e-init', () => {
         .name('name2')
         .run();
 
-      // confirm that it works but gave an info message about it
       expect(result.exitCode).toStrictEqual(0);
-      expect(result.stdout).toEqual(expect.stringContaining('INFO'));
-      expect(result.stdout).toEqual(expect.stringContaining('already exists'));
+      expect(result.stdout).toMatch('INFO');
+      expect(result.stdout).toMatch('already exists');
+      expect(result.stdout).toMatch(`OK if you are sharing ${root} between multiple build configs`);
     });
 
     it('refuses to use a pre-existing directory that lacks its own .gclient file', () => {

--- a/tests/e-remove-spec.js
+++ b/tests/e-remove-spec.js
@@ -22,9 +22,8 @@ describe('e-remove', () => {
       .name(name)
       .run();
     expect(result.exitCode).toStrictEqual(1);
-    expect(result.stderr).toEqual(
-      expect.stringContaining('ERR') && expect.stringContaining('not found'),
-    );
+    expect(result.stderr).toMatch(/ERR/);
+    expect(result.stderr).toMatch(/not found/);
   });
 
   it('fails if trying to remove a configuration that is currently in use', () => {
@@ -39,10 +38,10 @@ describe('e-remove', () => {
       .eRemoveRunner()
       .name(configNameToRemove)
       .run();
+
     expect(result.exitCode).toStrictEqual(1);
-    expect(result.stderr).toEqual(
-      expect.stringContaining('ERR') && expect.stringContaining('in use'),
-    );
+    expect(result.stderr).toMatch(/ERR/);
+    expect(result.stderr).toMatch(/in use/);
   });
 
   it('removes the specified configuration from our list', () => {
@@ -65,6 +64,6 @@ describe('e-remove', () => {
       .name(configNameToRemove)
       .run();
     expect(result.exitCode).toStrictEqual(0);
-    expect(result.stdout.toLowerCase()).toEqual(expect.stringContaining('removed'));
+    expect(result.stdout.toLowerCase()).toMatch(/removed/);
   });
 });


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/87.

Cleans up logic a bit to handle the case where `root` has been set to an existing directory but it's not been initialized with a `.gclient` file.

cc @MarshallOfSound @ckerr 