### PR TITLE
fix: goma ensure_start not exiting on Windows

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -173,7 +173,8 @@ function ensureGomaStart(config) {
       ...gomaEnv(config),
       ...subprocs,
     },
-    stdio: ['ignore'],
+    // Inherit stdio on Windows because otherwise this never terminates
+    stdio: process.platform === 'win32' ? 'inherit' : ['ignore'],
   });
 }
 


### PR DESCRIPTION
fixes #91

By inheriting stdio when running `goma_ctl.py ensure_start`, it eventually exits which it isn't doing currently. The side effect is that the user will see the output below when first starting a build.

```
$ e build -j 18
Running "goma_ctl.py ensure_start" in C:\Users\Sam\.electron_build_tools\third_party\goma
Login as Sam Maddock
Using Server: athos.notgoma.com:443
using C:\Users\Sam\AppData\Local\Temp\goma as tmpdir

GOMA version 3f080e0675d1a389a0fc6ac19a2354f4d7a70d01@1606175303
waiting for compiler_proxy to respond...
waiting for compiler_proxy to respond...
waiting for compiler_proxy to respond...
waiting for compiler_proxy to respond...
waiting for compiler_proxy to respond...
compiler proxy (pid=16468) status: http://127.0.0.1:8088 ok

Now goma is ready!

Running "ninja.exe -j 18 electron" in W:\electron\testing\src\out\Testing
[0/1] Regenerating ninja files
```