### PR TITLE
fix: use correct variable name in `guessPRTarget` warning

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -71,7 +71,7 @@ function guessPRTarget(config) {
   }
 
   console.warn(
-    `Unable to guess default target PR branch -- ${filename}'s version '${version}' should include 'nightly' or match ${pattern}`,
+    `Unable to guess default target PR branch -- ${filename}'s version '${version}' should include 'nightly' or match ${versionPattern}`,
   );
 }
 


### PR DESCRIPTION
That line was throwing a `ReferenceError` since `pattern` should be `versionPattern`.