### PR TITLE
refactor: remove unused variable 'oldConfig'

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -150,8 +150,6 @@ function sanitizeConfig(name, overwrite = false) {
   }
 
   if (config.origin) {
-    const oldConfig = color.config(util.inspect({ origin: config.origin }));
-
     config.remotes = {
       electron: {
         origin: config.origin.electron,


### PR DESCRIPTION
Literally just removes an unused variable.

This was added in 90a3e4e, where it was used in a console.log message. Later, 28d8282 removed the console.log call but not the variable.