### PR TITLE
fix: sysctl.proc_translated does not exist on x64 macOS

### DIFF
--- a/src/utils/arm.js
+++ b/src/utils/arm.js
@@ -1,12 +1,16 @@
 const cp = require('child_process');
 
 const getIsArm = () => {
-  const isCurrentlyTranslated = cp.execSync('sysctl sysctl.proc_translated');
+  if (process.arch === 'arm64') {
+    return true;
+  }
 
-  return (
-    process.arch === 'arm64' ||
-    isCurrentlyTranslated.toString().startsWith('sysctl.proc_translated: 1')
-  );
+  try {
+    const isCurrentlyTranslated = cp.execSync('sysctl sysctl.proc_translated', { stdio: 'pipe' });
+    return isCurrentlyTranslated.toString().startsWith('sysctl.proc_translated: 1');
+  } catch (e) {
+    return false;
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
```
Error: Command failed: sysctl sysctl.proc_translated
sysctl: unknown oid 'sysctl.proc_translated'
```