### PR TITLE
fix: error handling in ARM check

### DIFF
--- a/src/utils/arm.js
+++ b/src/utils/arm.js
@@ -1,12 +1,19 @@
 const cp = require('child_process');
 
+// See https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment.
 const getIsArm = () => {
-  const isCurrentlyTranslated = cp.execSync('sysctl sysctl.proc_translated');
+  try {
+    const isCurrentlyTranslated = cp.execSync('sysctl sysctl.proc_translated', { stdio: 'pipe' });
 
-  return (
-    process.arch === 'arm64' ||
-    isCurrentlyTranslated.toString().startsWith('sysctl.proc_translated: 1')
-  );
+    return (
+      process.arch === 'arm64' ||
+      isCurrentlyTranslated.toString().startsWith('sysctl.proc_translated: 1')
+    );
+  } catch (e) {
+    // On non-ARM macs `sysctl sysctl.proc_translated` throws with
+    // sysctl: unknown oid 'sysctl.proc_translated'
+    return false;
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
Fixes error introduced by https://github.com/electron/build-tools/commit/ca85ebfafb831bef27b0242c347db5e5de949bc7:

<details>

<summary>Stacktrace</summary>

```
electron on git:keyboard-lock ❯ e sync                                        2:01PM
Checking for build-tools updates
Running "git pull --rebase --autostash" in /Users/codebytere/build-tools
From https://github.com/electron/build-tools
   7651dbc..ca85ebf  master         -> origin/master
 * [new branch]      zcbenz-patch-1 -> origin/zcbenz-patch-1
Successfully rebased and updated refs/heads/master.
Running "npx yarn" in /Users/codebytere/build-tools
Updated to Latest Build Tools
sysctl: unknown oid 'sysctl.proc_translated'
node:child_process:747
    throw err;
    ^

Error: Command failed: sysctl sysctl.proc_translated
sysctl: unknown oid 'sysctl.proc_translated'

    at checkExecSyncError (node:child_process:707:11)
    at Object.execSync (node:child_process:744:15)
    at getIsArm (/Users/codebytere/build-tools/src/utils/arm.js:4:36)
    at Object.<anonymous> (/Users/codebytere/build-tools/src/utils/goma.js:20:34)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
    at require (node:internal/modules/cjs/helpers:93:18) {
  status: 1,
  signal: null,
  output: [
    null,
    Buffer(0) [Uint8Array] [],
    Buffer(45) [Uint8Array] [
      115, 121, 115,  99, 116, 108,  58,  32, 117,
      110, 107, 110, 111, 119, 110,  32, 111, 105,
      100,  32,  39, 115, 121, 115,  99, 116, 108,
       46, 112, 114, 111,  99,  95, 116, 114,  97,
      110, 115, 108,  97, 116, 101, 100,  39,  10
    ]
  ],
  pid: 16041,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(45) [Uint8Array] [
    115, 121, 115,  99, 116, 108,  58,  32, 117,
    110, 107, 110, 111, 119, 110,  32, 111, 105,
    100,  32,  39, 115, 121, 115,  99, 116, 108,
     46, 112, 114, 111,  99,  95, 116, 114,  97,
    110, 115, 108,  97, 116, 101, 100,  39,  10
  ]
}
```

</details>

On non-Arm macs a call to `sysctl sysctl.proc_translated` will error with `sysctl: unknown oid 'sysctl.proc_translated'`.
