### PR TITLE
feat: enable using build-tools with Chromium

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -31,7 +31,8 @@ function setRemotes(cwd, repo) {
   }
 }
 
-function runGClientSync(config, syncArgs, syncOpts) {
+function runGClientSync(syncArgs, syncOpts) {
+  const config = evmConfig.current();
   const srcdir = path.resolve(config.root, 'src');
   ensureDir(srcdir);
 
@@ -53,11 +54,14 @@ function runGClientSync(config, syncArgs, syncOpts) {
   };
   depot.execFileSync(config, exec, args, opts);
 
-  const electronPath = path.resolve(srcdir, 'electron');
-  const nodejsPath = path.resolve(srcdir, 'third_party', 'electron_node');
+  // Only set remotes if we're building an Electron target.
+  if (config.defaultTarget !== evmConfig.buildTargets.chromium) {
+    const electronPath = path.resolve(srcdir, 'electron');
+    const nodejsPath = path.resolve(srcdir, 'third_party', 'electron_node');
 
-  setRemotes(electronPath, config.remotes.electron);
-  setRemotes(nodejsPath, config.remotes.node);
+    setRemotes(electronPath, config.remotes.electron);
+    setRemotes(nodejsPath, config.remotes.node);
+  }
 }
 
 const opts = program
@@ -73,9 +77,7 @@ const opts = program
 try {
   const { threeWay } = opts;
   const { unknown: syncArgs } = program.parseOptions(process.argv);
-  runGClientSync(evmConfig.current(), syncArgs, {
-    threeWay,
-  });
+  runGClientSync(syncArgs, { threeWay });
 } catch (e) {
   fatal(e);
 }

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -22,7 +22,7 @@ function updateDepotTools() {
 function ensureDepotTools() {
   const depot_dir = DEPOT_TOOLS_DIR;
 
-  // if it doesn't exist, create it
+  // If it doesn't exist, create it.
   if (!fs.existsSync(depot_dir)) {
     console.log(`Cloning ${color.cmd('depot_tools')} into ${color.path(depot_dir)}`);
     const url = 'https://chromium.googlesource.com/chromium/tools/depot_tools.git';
@@ -30,7 +30,7 @@ function ensureDepotTools() {
     updateDepotTools();
   }
 
-  // if it's been awhile, update it
+  // If it's been awhile, update it.
   const now = new Date();
   const msec_per_day = 86400000;
   const days_before_pull = 14;


### PR DESCRIPTION
Fixes an issue where running `e sync` with an unaltered Chromium src checkout would fail to sync becuase it would try to set remotes for directories which didn't exist (`src/third_party/electron_node` and `src/electron`)