### PR TITLE
feat: allow build-tools to be used with non-standard (e.g. non-github) repositories

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -31,9 +31,11 @@ function createConfig(options) {
   if (options.tsan) gn_args.push('is_tsan=true');
 
   const electron = {
-    origin: options.useHttps
-      ? 'https://github.com/electron/electron.git'
-      : 'git@github.com:electron/electron.git',
+    origin:
+      options.repo ||
+      (options.useHttps
+        ? 'https://github.com/electron/electron.git'
+        : 'git@github.com:electron/electron.git'),
     ...(options.fork && {
       fork: options.useHttps
         ? `https://github.com/${options.fork}.git`
@@ -77,7 +79,7 @@ function runGClientConfig(config) {
     '--name',
     'src/electron',
     '--unmanaged',
-    'https://github.com/electron/electron',
+    config.remotes.electron.origin,
   ];
   const opts = {
     cwd: root,
@@ -144,6 +146,7 @@ program
     '--fork <username/electron>',
     `Add a remote fork of Electron with the name 'fork'. This should take the format 'username/electron'`,
   )
+  .option('--repo <url>', `Use other repositories(e.g. GitLab / Azure Devops)`)
   .parse(process.argv);
 
 if (!name) {

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -69,6 +69,23 @@ describe('e-init', () => {
       expect(config.gen.out).toStrictEqual('Testing');
     });
 
+    it('allow build-tools to be used with non-standard (e.g. non-github) repositories.', () => {
+      const root = path.resolve(sandbox.tmpdir, 'non-github');
+      const gclient_file = path.resolve(root, '.gclient');
+
+      const repoURL = 'https://repo_url.com/extra/repo/info';
+      const result = sandbox
+        .eInitRunner()
+        .name('non-standard')
+        .root(root)
+        .repo(repoURL)
+        .run();
+
+      expect(result.exitCode).toStrictEqual(0);
+      expect(fs.statSync(gclient_file).isFile()).toStrictEqual(true);
+      expect(fs.readFileSync(gclient_file, 'utf8').indexOf(repoURL) !== -1).toStrictEqual(true);
+    });
+
     it('logs an info message when the new build config root already has a .gclient file', () => {
       const root = path.resolve(sandbox.tmpdir, 'main');
 

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -75,6 +75,10 @@ function eInitRunner(execOptions) {
       args.push(`--use-https`);
       return o;
     },
+    repo: url => {
+      args.push(`--repo=${url}`);
+      return o;
+    },
     import: val => {
       args.push('--import', val);
       return o;


### PR DESCRIPTION
closed: https://github.com/electron/build-tools/issues/302