### PR TITLE
fix: detect xcode version after ci config change

### DIFF
--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -68,12 +68,12 @@ function expectedXcodeVersion() {
 
   // First check CI build_config.yml
   const buildConfYaml = path.resolve(root, 'src', 'electron', '.circleci', 'build_config.yml');
-  let match = /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
+  let match = fs.existsSync(buildConfYaml) && /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
 
   // Second check CI config.yml
   if (!match) {
     const configYaml = path.resolve(root, 'src', 'electron', '.circleci', 'config.yml');
-    match = /xcode: "(.+?)"/.exec(fs.readFileSync(configYaml, 'utf8'));
+    match = fs.existsSync(configYaml) && /xcode: "(.+?)"/.exec(fs.readFileSync(configYaml, 'utf8'));
   }
 
   if (!match) {

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -68,7 +68,8 @@ function expectedXcodeVersion() {
 
   // First check CI build_config.yml
   const buildConfYaml = path.resolve(root, 'src', 'electron', '.circleci', 'build_config.yml');
-  let match = fs.existsSync(buildConfYaml) && /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
+  let match =
+    fs.existsSync(buildConfYaml) && /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
 
   // Second check CI config.yml
   if (!match) {

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -66,14 +66,14 @@ function expectedXcodeVersion() {
   // NOTE: the location of CI's xcode definition changed in PR #31741 (or commit
   // 43f36b5 on the main branch)
 
-  // First check CI config.yml
-  const configYaml = path.resolve(root, 'src', 'electron', '.circleci', 'config.yml');
-  let match = /xcode: "(.+?)"/.exec(fs.readFileSync(configYaml, 'utf8'));
+  // First check CI build_config.yml
+  const buildConfYaml = path.resolve(root, 'src', 'electron', '.circleci', 'build_config.yml');
+  let match = /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
 
-  // Second check CI build_config.yml
+  // Second check CI config.yml
   if (!match) {
-    const buildConfYaml = path.resolve(root, 'src', 'electron', '.circleci', 'build_config.yml');
-    match = /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
+    const configYaml = path.resolve(root, 'src', 'electron', '.circleci', 'config.yml');
+    match = /xcode: "(.+?)"/.exec(fs.readFileSync(configYaml, 'utf8'));
   }
 
   if (!match) {

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -62,8 +62,20 @@ function getXcodeVersion() {
 
 function expectedXcodeVersion() {
   const { root } = evmConfig.current();
-  const yaml = path.resolve(root, 'src', 'electron', '.circleci', 'config.yml');
-  const match = /xcode: "(.+?)"/.exec(fs.readFileSync(yaml, 'utf8'));
+
+  // NOTE: the location of CI's xcode definition changed in PR #31741 (or commit
+  // 43f36b5 on the main branch)
+
+  // First check CI config.yml
+  const configYaml = path.resolve(root, 'src', 'electron', '.circleci', 'config.yml');
+  let match = /xcode: "(.+?)"/.exec(fs.readFileSync(configYaml, 'utf8'));
+
+  // Second check CI build_config.yml
+  if (!match) {
+    const buildConfYaml = path.resolve(root, 'src', 'electron', '.circleci', 'build_config.yml');
+    match = /xcode: "(.+?)"/.exec(fs.readFileSync(buildConfYaml, 'utf8'));
+  }
+
   if (!match) {
     console.warn(
       color.warn,


### PR DESCRIPTION
https://github.com/electron/electron/pull/31741 moved a lot of information in the Circle CI config `config.yml` to a new `build_config.yml` file. The Xcode detection code relied on finding Xcode info in that old file path. This PR introduces the new file path as the source of truth, but still checks the old path if the first one fails to preserve backwards compatibility with electron repos older than that PR. Not sure when the old path should be removed from build tools though.