### PR TITLE
fix: build failed

### DIFF
--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -62,7 +62,7 @@ function getXcodeVersion() {
 
 function expectedXcodeVersion() {
   const { root } = evmConfig.current();
-  const yaml = path.resolve(root, 'src', 'electron', '.circleci', 'config.yml');
+  const yaml = path.resolve(root, 'src', 'electron', '.circleci', 'build_config.yml');
   const match = /xcode: "(.+?)"/.exec(fs.readFileSync(yaml, 'utf8'));
   if (!match) {
     console.warn(


### PR DESCRIPTION
see: https://github.com/electron/electron/pull/31741

This PR moves the xcode field information from config.yml to build_config.yml

This caused build-tools to fail to read xcode information, thus downgrading to xcode version 11.1.0

![image](https://user-images.githubusercontent.com/8198408/145388949-0ca4110a-5ac6-428f-b13c-2a7657aaf295.png)
![image](https://user-images.githubusercontent.com/8198408/145389002-5a630259-714a-4d14-a433-a94153afb2ba.png)
