### PR TITLE
feat: expose e patches --list-targets

### DIFF
--- a/src/e
+++ b/src/e
@@ -149,7 +149,7 @@ program
   .command('show <subcommand>', 'Show info about the current build config')
   .command('test [specRunnerArgs...]', `Run Electron's spec runner`)
   .command('pr [options]', 'Open a GitHub URL where you can PR your changes')
-  .command('patches <basename>', 'Refresh the patches in $root/src/electron/patches/$basename')
+  .command('patches <target>', 'Refresh the patches in $root/src/electron/patches/$target')
   .command('open <sha1|PR#>', 'Open a GitHub URL for the given commit hash / pull # / issue #')
   .command(
     'load-xcode',

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -88,7 +88,7 @@ program
   .allowUnknownOption()
   .arguments('[target] [ninjaArgs...]')
   .description('Build Electron and other targets.')
-  .option('--list-targets', 'Show all supported targets', false)
+  .option('--list-targets', 'Show all supported build targets', false)
   .option('--gen', 'Force a re-run of `gn gen` before building', false)
   .option('-t|--target [target]', 'Forces a specific ninja target')
   .option('--no-goma', 'Build without goma', false)


### PR DESCRIPTION
Allow for listing all patch targets without re-exporting patches.