### PR TITLE
chore: don't add depot_tools to PATH if already there

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -95,7 +95,9 @@ function depotOpts(config, opts = {}) {
       paths.push(path.resolve(DEPOT_TOOLS_DIR, fs.readFileSync(pythonRelDirFile, 'utf8').trim()));
     }
   }
-  opts.env[key] = [...paths, process.env[key]].join(path.delimiter);
+  // Remove any duplicates on path so that DEPOT_TOOLS_DIR isn't added if it is already there
+  const currentPath = process.env[key].split(path.delimiter);
+  opts.env[key] = Array.from(new Set([...paths, ...currentPath])).join(path.delimiter);
 
   return opts;
 }


### PR DESCRIPTION
Was noticing that if `depot_tools` is already at the start of your `PATH`, `e show env` still adds it to the front. Not functionally a problem, but does make it so `e show env` will never return clean since it will always modify `PATH` even if it doesn't need to.