### PR TITLE
feat: ability to use system xcode

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -184,6 +184,14 @@ function sanitizeConfig(name, overwrite = false) {
     changes.push(`replaced superceded 'origin' property with 'remotes' property`);
   }
 
+  if (config.xcode) {
+    if (!['default', 'system'].includes(config.xcode)) {
+      fatal(`Invalid 'xcode' specified in config, options are 'default' or 'system'`);
+    }
+  } else {
+    config.xcode = 'default';
+  }
+
   if (
     config.goma !== 'none' &&
     config.gen &&

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -184,12 +184,10 @@ function sanitizeConfig(name, overwrite = false) {
     changes.push(`replaced superceded 'origin' property with 'remotes' property`);
   }
 
-  if (config.xcode) {
-    if (!['default', 'system'].includes(config.xcode)) {
-      fatal(`Invalid 'xcode' specified in config, options are 'default' or 'system'`);
-    }
-  } else {
-    config.xcode = 'default';
+  config.xcode = config.xcode || 'default';
+
+  if (!['default', 'system'].includes(config.xcode)) {
+    fatal(`Invalid 'xcode' specified in config, options are 'default' or 'system'`);
   }
 
   if (


### PR DESCRIPTION
This PR adds the ability to use system version of XCode (installed in `/Applications`) on Mac OS build hosts by setting a new optional root-level directive in the `e config` file.

The new directive as an example:

```
{
  "goma": "none",
  "root": "build/root/dir",
  "xcode": "system",
  ......
```

Valid values are `'system'` or `'default'`. If not present, `'default'` is assumed.