### PR TITLE
fix: call gclient directly instead of via Python

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -70,9 +70,8 @@ function createConfig(options) {
 function runGClientConfig(config) {
   const { root } = config;
   depot.ensure();
-  const exec = 'python';
+  const exec = 'gclient';
   const args = [
-    'gclient.py',
     'config',
     '--name',
     'src/electron',
@@ -81,8 +80,9 @@ function runGClientConfig(config) {
   ];
   const opts = {
     cwd: root,
+    shell: true,
   };
-  depot.execFileSync(config, exec, args, opts);
+  depot.spawnSync(config, exec, args, opts);
 }
 
 function ensureRoot(config, force) {

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -42,17 +42,18 @@ function runGClientSync(syncArgs, syncOpts) {
 
   depot.ensure();
 
-  const exec = 'python';
-  const args = ['gclient.py', 'sync', '--with_branch_heads', '--with_tags', '-vv', ...syncArgs];
+  const exec = 'gclient';
+  const args = ['sync', '--with_branch_heads', '--with_tags', '-vv', ...syncArgs];
   const opts = {
     cwd: srcdir,
+    shell: true,
     env: syncOpts.threeWay
       ? {
           ELECTRON_USE_THREE_WAY_MERGE_FOR_PATCHES: 'true',
         }
       : {},
   };
-  depot.execFileSync(config, exec, args, opts);
+  depot.spawnSync(config, exec, args, opts);
 
   // Only set remotes if we're building an Electron target.
   if (config.defaultTarget !== evmConfig.buildTargets.chromium) {


### PR DESCRIPTION
Fixes #330.

I believe that issue was caused by [this CL landing](https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/3445785) which moved `gclient` to Python 3, and the way `build-tools` was invoking `gclient` skips over the `vpython3` stuff, so the `httplib2` library wasn't being installed in the venv.