### PR TITLE
revert: upgrade commander 3.x->9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@octokit/rest": "^18.5.2",
     "chalk": "^2.4.1",
     "command-exists": "^1.2.8",
-    "commander": "^9.0.0",
+    "commander": "^3.0.2",
     "cross-zip": "^3.0.0",
     "debug": "^4.3.1",
     "got": "^10.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,15 +1088,15 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
+commander@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
+  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
 commander@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
   integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
-
-commander@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
-  integrity sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This reverts commit 7f989cba6fbba1b2d41dbc324d1cf2369d6e5e44.

This brought some unexpected changed and adaptation we weren't aware we needed to make, so let's back this out and do it in another PR to handle e.g:

https://github.com/tj/commander.js/pull/1652
https://github.com/tj/commander.js/pull/1048