### PR TITLE
chore: run Jest tests serially

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "lint": "prettier --check \"src/**/*.js\" \"tests/*.js\" \"src/e\"",
     "prettier:write": "prettier --write \"src/**/*.js\" \"tests/*.js\" \"src/e\"",
-    "test": "nyc --reporter=lcov --reporter=text-summary jest --config=jest.fast.json",
-    "test:all": "nyc --reporter=lcov --reporter=text-summary jest --config=jest.slow.json"
+    "test": "nyc --reporter=lcov --reporter=text-summary jest --config=jest.fast.json -i",
+    "test:all": "nyc --reporter=lcov --reporter=text-summary jest --config=jest.slow.json -i"
   },
   "repository": "https://github.com/electron/build-tools",
   "author": "Electron Authors",


### PR DESCRIPTION
Tracked down some testing flakiness due to this. By default, Jest will run each test file in parallel. Since `depot_tools` gets cloned into the source checkout directory, that means each of those parallel test runs are using a single `depot_tools` checkout, creating a race condition depending on the state of that checkout as tests go. I believe that's the root cause of #208, so we can enable macOS CI once this lands.

I also considered changing `DEPOT_TOOLS_DIR` for the sandbox env in `createSandbox`, but that slows down tests significantly since it clones per-test.

You could try to clone `depot_tools` per test file, but running the tests serially like in this PR has little real world impact on test run time, so it seems like the cleanest fix.

@codebytere @ckerr