### PR TITLE
chore: goma.isAuthenticated() takes no parameters

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -36,7 +36,7 @@ function runNinja(config, target, useGoma, ninjaArgs) {
     goma.downloadAndPrepare(config);
 
     if (config.goma === 'cluster') {
-      const authenticated = goma.isAuthenticated(config.root);
+      const authenticated = goma.isAuthenticated();
       if (!authenticated) {
         console.log('Not Authenticated - Triggering Goma Login');
         const { status, error } = depot.spawnSync(


### PR DESCRIPTION
Looks like this was missed in 635d114e4e1573aed2052141489bdac15bdd26ab when that function was changed.