### PR TITLE
chore: pywin32 is no longer needed on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,6 @@ jobs:
         git config --global core.eol lf
         git config --global core.filemode false
         git config --global branch.autosetuprebase always
-    - name: Install dependencies (Windows)
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: pip install pywin32
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1


### PR DESCRIPTION
Follow-up to #363 to also remove `pywin32` from CI.