### PR TITLE
chore: fix typo in description of `e cherry-pick`

### DIFF
--- a/src/e
+++ b/src/e
@@ -160,7 +160,7 @@ program
   .command('auto-update', 'Check for build-tools updates or enable/disable automatic updates')
   .alias('check-for-updates')
   .command(
-    'cherry-pick <patch-url> <target-branch> [additionBranches...]',
+    'cherry-pick <patch-url> <target-branch> [additionalBranches...]',
     'Opens a PR to electron/electron that backport the given CL into our patches folder',
   )
   .alias('auto-cherry-pick')


### PR DESCRIPTION
Brings it inline with the description in `e-cherry-pick.js`