### PR TITLE
fix: undefined error message

### DIFF
--- a/src/e
+++ b/src/e
@@ -213,9 +213,9 @@ program
       },
     });
     if (status !== 0) {
-      console.error(
-        `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
-      );
+      let errorMsg = `${color.err} Failed to run command, exit code was "${status}"`;
+      if (error) errorMsg += `, error was '${error}'`;
+      console.error(errorMsg);
     }
     process.exit(status);
   });


### PR DESCRIPTION
Fixes the following error sometimes seen when commands fail:

```
ERROR Failed to run command, exit code was "1", error was 'undefined'
```