### PR TITLE
fix: properly handle target argument in `e build`

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -125,14 +125,24 @@ program
         runGNGen(config);
       }
 
-      // collect all the unrecognized args that aren't a target
-      const pretty = Object.keys(targets).find(p => program.rawArgs.includes(p)) || 'default';
-      const index = ninjaArgs.indexOf(pretty);
-      if (index != -1) {
-        ninjaArgs.splice(index, 1);
+      if (options.target) {
+        // User forced a target, so any arguments are ninjaArgs
+        if (target) {
+          ninjaArgs.unshift(target);
+        }
+        target = options.target;
+      } else if (Object.keys(targets).includes(target)) {
+        target = targets[target];
+      } else {
+        // No forced target and no target matched, so use the
+        // default target and assume any arguments are ninjaArgs
+        if (target) {
+          ninjaArgs.unshift(target);
+        }
+        target = targets['default'];
       }
 
-      runNinja(config, target || targets[pretty], options.goma, ninjaArgs);
+      runNinja(config, target, options.goma, ninjaArgs);
     } catch (e) {
       fatal(e);
     }


### PR DESCRIPTION
Not sure if this is fall out from the commander upgrade (seems plausible given the code's usage of `rawArgs`), but currently providing a target argument to `e build` isn't working since it doesn't map it to the correct name.

This tightens up the different ways a target can be provided and I think handles all cases robustly now.

Came from https://github.com/electron/electron/pull/33355 where it was showing up in the wild.

@codebytere 