### PR TITLE
fix: make forks work with `e pr` again

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -91,7 +91,9 @@ function pullRequestSource(source) {
     /git@github.com:(\S*)\/electron.git/,
   ];
 
-  if (current().remotes.electron.fork) {
+  const config = current();
+
+  if (config.remotes.electron.fork) {
     const command = 'git remote get-url fork';
     const cwd = path.resolve(config.root, 'src', 'electron');
     const options = { cwd, encoding: 'utf8' };


### PR DESCRIPTION
Looks like this got inadvertently broken in #336, so just restoring the previous functionality.