### PR TITLE
chore: bump Node engine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "build-tools",
   "version": "0.2.0",
   "engines": {
-    "node": ">= 10.12.0"
+    "node": ">= 12.20.0"
   },
   "main": "null",
   "private": true,


### PR DESCRIPTION
[Commander v9 requires Node 12.20.0+](https://github.com/tj/commander.js/blob/master/CHANGELOG.md#900-2022-01-28)