### PR TITLE
chore: don't use program.rawArgs

### DIFF
--- a/src/e
+++ b/src/e
@@ -72,7 +72,7 @@ program
   .alias('run')
   .description('Run the Electron executable')
   .allowUnknownOption()
-  .action((args) => {
+  .action(args => {
     try {
       const exec = evmConfig.execOf(evmConfig.current());
       const opts = { stdio: 'inherit' };
@@ -95,7 +95,7 @@ program
   .command('node [args...]')
   .description('Run the Electron build as if it were a Node.js executable')
   .allowUnknownOption()
-  .action((args) => {
+  .action(args => {
     try {
       const exec = evmConfig.execOf(evmConfig.current());
       const opts = {

--- a/src/e
+++ b/src/e
@@ -68,14 +68,13 @@ program
   .alias('make');
 
 program
-  .command('start')
+  .command('start [args...]')
   .alias('run')
   .description('Run the Electron executable')
   .allowUnknownOption()
-  .action(() => {
+  .action((args) => {
     try {
       const exec = evmConfig.execOf(evmConfig.current());
-      const args = program.rawArgs.slice(3);
       const opts = { stdio: 'inherit' };
       console.log(color.childExec(exec, args, opts));
       childProcess.execFileSync(exec, args, opts);
@@ -93,13 +92,12 @@ program
   });
 
 program
-  .command('node')
+  .command('node [args...]')
   .description('Run the Electron build as if it were a Node.js executable')
   .allowUnknownOption()
-  .action(() => {
+  .action((args) => {
     try {
       const exec = evmConfig.execOf(evmConfig.current());
-      const args = program.rawArgs.slice(3);
       const opts = {
         env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
         stdio: 'inherit',


### PR DESCRIPTION
Commander offers a cleaner way to do this, should be no functional change.