### PR TITLE
chore: remove pywin32 dependency check

### DIFF
--- a/src/utils/deps-check.js
+++ b/src/utils/deps-check.js
@@ -30,16 +30,6 @@ const deps = {
       },
       deps: ['choco'],
     },
-    {
-      cmd: 'pywin32',
-      check: () => {
-        return cp.spawnSync('python', ['-c', 'import win32process']).status === 0;
-      },
-      fix: () => {
-        spawnSyncWithLog('choco', ['install', 'pywin32', '--yes']);
-      },
-      deps: ['choco'],
-    },
   ],
 };
 


### PR DESCRIPTION
https://github.com/electron/electron/pull/26186 removed the need for pywin32, so we should remove that dependency check from build-tools