### PR TITLE
feat: support webrtc and pdfium cherry-picks

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -58,7 +58,9 @@ program
       const gerritUrl = new URL(patchUrlStr);
       if (
         gerritUrl.host !== 'chromium-review.googlesource.com' &&
-        gerritUrl.host !== 'skia-review.googlesource.com'
+        gerritUrl.host !== 'skia-review.googlesource.com' &&
+        gerritUrl.host !== 'webrtc-review.googlesource.com' &&
+        gerritUrl.host !== 'pdfium-review.googlesource.com'
       ) {
         fatal(
           'Expected a gerrit URL (e.g. https://chromium-review.googlesource.com/c/v8/v8/+/2465830)',
@@ -78,9 +80,10 @@ program
 
       const patchDirName =
         {
-          'chromium/src': 'chromium',
-          skia: 'skia',
-        }[repo] || repo.split('/')[1];
+          'chromium-review.googlesource.com:chromium/src': 'chromium',
+          'skia-review.googlesource.com:skia': 'skia',
+          'webrtc-review.googlesource.com:src': 'webrtc',
+        }[gerritUrl.host + ':' + repo] || repo.split('/')[1];
 
       const shortCommit = commitId.substr(0, 12);
       const patchName = `cherry-pick-${shortCommit}.patch`;

--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -83,7 +83,7 @@ program
           'chromium-review.googlesource.com:chromium/src': 'chromium',
           'skia-review.googlesource.com:skia': 'skia',
           'webrtc-review.googlesource.com:src': 'webrtc',
-        }[gerritUrl.host + ':' + repo] || repo.split('/')[1];
+        }[gerritUrl.host + ':' + repo] || repo.split('/').reverse()[0];
 
       const shortCommit = commitId.substr(0, 12);
       const patchName = `cherry-pick-${shortCommit}.patch`;


### PR DESCRIPTION
Adds support for webrtc and pdfium gerrit links, eg.

https://pdfium-review.googlesource.com/c/pdfium/+/88290

and

https://webrtc-review.googlesource.com/c/src/+/251841

(this latter one necessitating the addition of the host name to the repo name
lookup)
