### PR TITLE
feat: use the new az storage for build tools things

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -48,8 +48,7 @@ function platformOpts() {
     case 'win32':
       opts = {
         DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
-        DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL:
-          'https://electron-build-tools.s3-us-west-2.amazonaws.com/win32/toolchains/_',
+        DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL: 'https://dev-cdn.electronjs.org/windows-toolchains/_',
         GYP_MSVS_HASH_9ff60e43ba91947baca460d0ca3b1b980c3a2c23:
           '6d205e765a23d3cbe0fcc8d1191ae406d8bf9c04',
         GYP_MSVS_HASH_a687d8e2e4114d9015eb550e1b156af21381faac:

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -12,7 +12,7 @@ const { getIsArm } = require('./arm');
 const gomaDir = path.resolve(__dirname, '..', '..', 'third_party', 'goma');
 const gomaGnFile = path.resolve(__dirname, '..', '..', 'third_party', 'goma.gn');
 const gomaShaFile = path.resolve(__dirname, '..', '..', 'third_party', 'goma', '.sha');
-const gomaBaseURL = 'https://electron-build-tools.s3-us-west-2.amazonaws.com/build-dependencies';
+const gomaBaseURL = 'https://dev-cdn.electronjs.org/goma-clients';
 const gomaLoginFile = path.resolve(gomaDir, 'last-known-login');
 
 let gomaPlatform = process.platform;

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -11,8 +11,7 @@ const { color, fatal } = require('./logging');
 const XcodeDir = path.resolve(__dirname, '..', '..', 'third_party', 'Xcode');
 const XcodePath = path.resolve(XcodeDir, 'Xcode.app');
 const XcodeZip = path.resolve(XcodeDir, 'Xcode.zip');
-const XcodeBaseURL = `${process.env.ELECTRON_BUILD_TOOLS_MIRROR ||
-  'https://electron-build-tools.s3-us-west-2.amazonaws.com'}/macos/`;
+const XcodeBaseURL = 'https://dev-cdn.electronjs.org/xcode/';
 
 const XcodeVersions = {
   '9.4.1': {


### PR DESCRIPTION
Good bye S3 bucket, hello `dev-cdn.electronjs.org.