### PR TITLE
fix: clean up error messaging a bit

### DIFF
--- a/src/e
+++ b/src/e
@@ -212,11 +212,14 @@ program
         ELECTRON_OVERRIDE_DIST_PATH: evmConfig.outDir(evmConfig.current()),
       },
     });
+
     if (status !== 0) {
-      let errorMsg = `${color.err} Failed to run command, exit code was "${status}"`;
-      if (error) errorMsg += `, error was '${error}'`;
+      let errorMsg = `${color.err} Failed to run command:`;
+      if (status !== null) errorMsg += `\n Exit Code: "${status}"`;
+      if (error) errorMsg += `\n ${error}`;
       console.error(errorMsg);
     }
+
     process.exit(status);
   });
 
@@ -252,11 +255,14 @@ program
         AGREE_NOTGOMA_TOS: '1',
       },
     });
+
     if (status !== 0) {
-      console.error(
-        `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
-      );
+      let errorMsg = `${color.err} Failed to run command:`;
+      if (status !== null) errorMsg += `\n Exit Code: "${status}"`;
+      if (error) errorMsg += `\n ${error}`;
+      console.error(errorMsg);
     }
+
     process.exit(status);
   });
 


### PR DESCRIPTION
Before:

```
ERROR Failed to run command, exit code was "1", error was 'Error: spawnSync python ENOENT'
```

After:

```
ERROR Failed to run command:
 Exit Code: "1"
 Error: 'spawnSync python ENOENT'
 ```
 
 Also makes it such that if the exit code is null or there is no error, we don't show them.