### PR TITLE
chore: don't use return statements outside of func

### DIFF
--- a/src/e-load-xcode.js
+++ b/src/e-load-xcode.js
@@ -90,11 +90,11 @@ for (const sdk of SDK_TO_UNLINK) {
 
   // Check that target is a valid symbolic link.
   const stats = fs.lstatSync(targetDirectory);
-  if (!stats.isSymbolicLink()) return;
+  if (!stats.isSymbolicLink()) continue;
 
   // Check if the link is to the default SDK that we should have
   if (fs.realpathSync(targetDirectory) === fs.realpathSync(path.resolve(xCodeSDKDir, 'MacOSX.sdk')))
-    return;
+    continue;
 
   console.warn(`${color.info} Removing symbolic link ${color.path(targetDirectory)}`);
 


### PR DESCRIPTION
I think these are meant to be `continue`, was poking around in code and they got flagged as `return` statements outside of a func.