### PR TITLE
feat: add e ci rerun [workflow]

### DIFF
--- a/src/ci/ci-rerun.js
+++ b/src/ci/ci-rerun.js
@@ -9,7 +9,7 @@ const { fatal } = require('../utils/logging');
 program
   .description('Rerun CI workflows')
   .argument('[workflow]', 'The ID of the workflow to rerun')
-  .option('-f, --from-failed', 'Rerun workflow from failed', false)
+  .option('-f, --from-failed', 'Rerun workflow from failed', true)
   .option('-e, --enable-ssh', 'Rerun workflow from failed', false)
   .action(async (workflow, options) => {
     try {

--- a/src/ci/ci-rerun.js
+++ b/src/ci/ci-rerun.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const { default: chalk } = require('chalk');
+const program = require('commander');
+const got = require('got');
+
+const { fatal } = require('../utils/logging');
+
+program
+  .description('Show information about CI job statuses')
+  .argument('[workflow]', 'The ID of the workflow to rerun')
+  .option('-f, --from-failed', 'Rerun workflow from failed', false)
+  .option('-e, --enable-ssh', 'Rerun workflow from failed', false)
+  .action(async (workflow, options) => {
+    try {
+      const { pipeline_number } = await got(`https://circleci.com/api/v2/workflow/${workflow}`, {
+        username: process.env.CIRCLE_TOKEN,
+        password: '',
+      }).json();
+
+      const { workflow_id } = await got
+        .post(`https://circleci.com/api/v2/workflow/${workflow}/rerun`, {
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          username: process.env.CIRCLE_TOKEN,
+          password: '',
+          json: {
+            enable_ssh: options.enableSsh,
+            from_failed: options.fromFailed,
+            jobs: [],
+            sparse_tree: false,
+          },
+        })
+        .json();
+
+      console.log(`${chalk.bgMagenta(chalk.white('New Workflow Run'))}
+
+  ⦿ ${chalk.white(
+    `https://app.circleci.com/pipelines/github/electron/electron/${pipeline_number}/workflows/${workflow_id}`,
+  )}
+      `);
+    } catch (e) {
+      fatal(e.message);
+    }
+  });
+
+program.parse(process.argv);

--- a/src/ci/ci-rerun.js
+++ b/src/ci/ci-rerun.js
@@ -7,7 +7,7 @@ const got = require('got');
 const { fatal } = require('../utils/logging');
 
 program
-  .description('Show information about CI job statuses')
+  .description('Rerun CI workflows')
   .argument('[workflow]', 'The ID of the workflow to rerun')
   .option('-f, --from-failed', 'Rerun workflow from failed', false)
   .option('-e, --enable-ssh', 'Rerun workflow from failed', false)

--- a/src/ci/ci-rerun.js
+++ b/src/ci/ci-rerun.js
@@ -10,7 +10,6 @@ program
   .description('Rerun CI workflows')
   .argument('[workflow]', 'The ID of the workflow to rerun')
   .option('-f, --from-failed', 'Rerun workflow from failed', true)
-  .option('-e, --enable-ssh', 'Rerun workflow from failed', false)
   .action(async (workflow, options) => {
     try {
       const { pipeline_number } = await got(`https://circleci.com/api/v2/workflow/${workflow}`, {
@@ -27,7 +26,8 @@ program
           username: process.env.CIRCLE_TOKEN,
           password: '',
           json: {
-            enable_ssh: options.enableSsh,
+            //TODO(codebytere): allow specifying jobs and rerunning with SSH.
+            enable_ssh: false,
             from_failed: options.fromFailed,
             jobs: [],
             sparse_tree: false,

--- a/src/e
+++ b/src/e
@@ -167,6 +167,7 @@ program
 
 const ci = program.command('ci').executableDir(path.join(__dirname, 'ci'));
 ci.command('status', 'Show information about CI job statuses');
+ci.command('rerun', 'Rerun CI workflows');
 
 program
   .command('update-goma')


### PR DESCRIPTION
Needs rebase when https://github.com/electron/build-tools/pull/379 is merged.

Adds the ability to re-run a given CircleCi Workflow.

```
build-tools on git:add-ci-rerun ❯ e ci rerun 26a85a7a-0c4c-4942-a6e0-5893b0643e18 --from-failed

New Workflow Run

  ⦿ https://app.circleci.com/pipelines/github/electron/electron/54278/workflows/556a9538-fa82-46ad-94ce-b615b50f1d3b
```

Also tested with https://github.com/electron/electron/pull/34454.