### PR TITLE
chore: refactor to use `goma.auth` in `e-build.js`

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -35,33 +35,9 @@ function runNinja(config, target, useGoma, ninjaArgs) {
   if (useGoma && config.goma !== 'none') {
     goma.downloadAndPrepare(config);
 
+    // maybe authenticate with Goma
     if (config.goma === 'cluster') {
-      const authenticated = goma.isAuthenticated();
-      if (!authenticated) {
-        console.log('Not Authenticated - Triggering Goma Login');
-        const { status, error } = depot.spawnSync(
-          evmConfig.current(),
-          'python',
-          ['goma_auth.py', 'login'],
-          {
-            cwd: goma.dir,
-            stdio: 'inherit',
-            env: {
-              ...process.env,
-              AGREE_NOTGOMA_TOS: '1',
-            },
-          },
-        );
-
-        if (status !== 0) {
-          console.error(
-            `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
-          );
-          process.exit(status);
-        }
-
-        goma.recordGomaLoginTime();
-      }
+      goma.auth(config);
     }
 
     goma.ensure(config);

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -154,10 +154,11 @@ function authenticateGoma(config) {
       },
     });
 
-    if (status !== 0) {
-      console.error(
-        `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
-      );
+    if (status !== 0) { 
+      let errorMsg = `${color.err} Failed to run command:`;
+      if (status !== null) errorMsg += `\n Exit Code: "${status}"`;
+      if (error) errorMsg += `\n ${error}`;
+      console.error(errorMsg);
       process.exit(status);
     }
 

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -145,7 +145,7 @@ function authenticateGoma(config) {
 
   if (!gomaIsAuthenticated()) {
     console.log(color.childExec('goma_auth.py', ['login'], { cwd: gomaDir }));
-    childProcess.execFileSync('python', ['goma_auth.py', 'login'], {
+    const { status, error } = depot.spawnSync('python', ['goma_auth.py', 'login'], {
       cwd: gomaDir,
       stdio: 'inherit',
       env: {
@@ -153,6 +153,14 @@ function authenticateGoma(config) {
         AGREE_NOTGOMA_TOS: '1',
       },
     });
+
+    if (status !== 0) {
+      console.error(
+        `${color.err} Failed to run command, exit code was "${status}", error was '${error}'`,
+      );
+      process.exit(status);
+    }
+
     recordGomaLoginTime();
   }
 }

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -154,7 +154,7 @@ function authenticateGoma(config) {
       },
     });
 
-    if (status !== 0) { 
+    if (status !== 0) {
       let errorMsg = `${color.err} Failed to run command:`;
       if (status !== null) errorMsg += `\n Exit Code: "${status}"`;
       if (error) errorMsg += `\n ${error}`;


### PR DESCRIPTION
Removes duplicated code and brings it into line with the code in `e-init.js`

There's slight changes in behavior here, namely:

- "Not Authenticated - Triggering Goma Login" will no longer be output from `e build`
- For Goma cluster users, `e init` will now fatal error if the Goma auth process exits with a non-zero status code, which would cause it to bail before building when `--bootstrap` is used. I think this is actually a good thing, as previously that case would have marked the login time down suppressing another attempt for 12 hours, and would have started the build with unauthenticated Goma access