### PR TITLE
feat: enable showing jobs in `e ci status`

### DIFF
--- a/src/ci/ci-status.js
+++ b/src/ci/ci-status.js
@@ -54,8 +54,8 @@ const printChecks = checks => {
     result += `  ⦿ ${name} - ${status} - ${url}\n`;
     if (check.jobs) {
       for (const job of check.jobs) {
-        const { id, status } = job;
-        result += `   ⦿ ${colorForStatus(status)} - ${id}\n`;
+        const { id, name, status } = job;
+        result += `     ⦿ ${name} - ${colorForStatus(status)} - ${id}\n`;
       }
     }
   }

--- a/src/ci/ci-status.js
+++ b/src/ci/ci-status.js
@@ -159,6 +159,7 @@ program
 
       if (options.showJobs) {
         for (const [name, check] of Object.entries(checks)) {
+          if (!check) continue;
           const workflowID = new URL(check.details_url).pathname.replace('/workflow-run/', '');
           const { items: jobs } = await got(
             `https://circleci.com/api/v2/workflow/${workflowID}/job`,


### PR DESCRIPTION
Enable showing individual job status and job IDs for individual checks in `e ci status`.

```
build-tools on git:ci-status-show-jobs ❯ e ci status -s                    10:08AM
Electron CI Status
  Ref: main

  Circle CI
  ⦿ macOS - failed - https://circleci.com/workflow-run/72f39358-9341-4a20-b36a-6220789d44b0
     ⦿ success mac-make-src-cache, mas-testing-arm64, mas-testing-arm64-tests, mas-testing-x64, mas-testing-x64-tests, mas-testing-x64-gn-check, osx-testing-arm64, osx-testing-arm64-tests, osx-testing-x64, osx-testing-x64-gn-check
     ⦿ failed - osx-testing-x64-tests - 636701d1-19f4-484d-b23b-995378041905

  ⦿ Linux - success - https://circleci.com/workflow-run/636344b2-ebd4-49c2-95ce-631ecd548b73
     ⦿ all jobs succeeded

  ⦿ Lint - success - https://circleci.com/workflow-run/f3e7db2a-2734-4161-a529-535a25726098
     ⦿ all jobs succeeded


  Appveyor
  ⦿ Windows x64 - Success - https://ci.appveyor.com/project/electron-bot/electron-ljo26/builds/43857449

  ⦿ Windows x64 (PR) - Missing

  ⦿ Windows ia32 - Success - https://ci.appveyor.com/project/electron-bot/electron-ia32-testing/builds/43857450

  ⦿ Windows ia32 (PR) - Missing

  ⦿ Windows Arm - Success - https://ci.appveyor.com/project/electron-bot/electron-ldhmv/builds/43857451
```