### PR TITLE
fix: show Appveyor PR runs for forks

### DIFF
--- a/src/ci/ci-status.js
+++ b/src/ci/ci-status.js
@@ -90,9 +90,17 @@ program
         ({ creator, context }) =>
           creator.id === APPVEYOR_BOT_ID && context === 'appveyor: win-x64-testing',
       );
+      const win64PR = statuses.find(
+        ({ creator, context }) =>
+          creator.id === APPVEYOR_BOT_ID && context === 'appveyor: win-x64-testing-pr',
+      );
       const win32 = statuses.find(
         ({ creator, context }) =>
           creator.id === APPVEYOR_BOT_ID && context === 'appveyor: win-ia32-testing',
+      );
+      const win32PR = statuses.find(
+        ({ creator, context }) =>
+          creator.id === APPVEYOR_BOT_ID && context === 'appveyor: win-ia32-testing-pr',
       );
       const woa = statuses.find(
         ({ creator, context }) =>
@@ -109,7 +117,9 @@ program
 
   ${chalk.bold(chalk.bgBlue(chalk.white('Appveyor')))}
   ${statusLine(win32, 'Windows ia32')}
+  ${statusLine(win32PR, 'Windows i32 (PR)')}
   ${statusLine(win64, 'Windows x64')}
+  ${statusLine(win64PR, 'Windows x64 (PR)')}
   ${statusLine(woa, 'Windows Arm')}`);
     } catch (e) {
       fatal(e.message);


### PR DESCRIPTION
Fixes missing CI runs for PRs from forks, e.g. https://github.com/electron/electron/pull/34525 which would show all Appveyor runs as missing.

After:

```
build-tools on git:add-missing-fork-sections ❯ e ci status -r 34418            12:15PM
Electron CI Status
  Ref: refs/pull/34418/head

  Circle CI
  ⦿ macOS - Failed - https://circleci.com/workflow-run/39ccb86c-40f5-44fc-8e4e-855757f53e38
  ⦿ Linux - Failed - https://circleci.com/workflow-run/80de547f-646c-4ee5-a62f-f9afbd319a9c
  ⦿ Lint - Failed - https://circleci.com/workflow-run/60aaf76f-1725-405a-8785-92ee70a2d99b

  Appveyor
  ⦿ Windows ia32 - Missing
  ⦿ Windows i32 (PR) - Success - https://ci.appveyor.com/project/electron-bot/electron-92tg5/builds/43734720
  ⦿ Windows x64 - Missing
  ⦿ Windows x64 (PR) - Success - https://ci.appveyor.com/project/electron-bot/electron-x64-testing-pr/builds/43734721
  ⦿ Windows Arm - Missing
```

Will need to be cleaned up a bit in https://github.com/electron/build-tools/pull/383