### PR TITLE
chore: use depot_tools environment for Goma client commands

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -114,12 +114,12 @@ function depotSpawnSync(config, cmd, args, opts_in) {
 }
 
 function depotExecFileSync(config, exec, args, opts_in) {
-  if (exec === 'python' && !path.isAbsolute(args[0])) {
+  const opts = depotOpts(config, opts_in);
+  if (exec === 'python' && !opts.cwd && !path.isAbsolute(args[0])) {
     args[0] = path.resolve(DEPOT_TOOLS_DIR, args[0]);
   }
-  const opts = depotOpts(config, opts_in);
   console.log(color.childExec(exec, args, opts));
-  childProcess.execFileSync(exec, args, opts);
+  return childProcess.execFileSync(exec, args, opts);
 }
 
 module.exports = {

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -68,7 +68,7 @@ function downloadAndPrepareGoma(config) {
   }[gomaPlatform];
 
   if (fs.existsSync(path.resolve(gomaDir, 'goma_ctl.py'))) {
-    depot.spawnSync(config, 'python', ['goma_ctl.py', 'stop'], {
+    depot.execFileSync(config, 'python', ['goma_ctl.py', 'stop'], {
       cwd: gomaDir,
       stdio: ['ignore'],
     });
@@ -118,7 +118,7 @@ function downloadAndPrepareGoma(config) {
   return sha;
 }
 
-function gomaIsAuthenticated() {
+function gomaIsAuthenticated(config) {
   if (!isSupportedPlatform) return false;
   const lastKnownLogin = getLastKnownLoginTime();
   // Assume if we authed in the last 12 hours it is still valid
@@ -126,7 +126,7 @@ function gomaIsAuthenticated() {
 
   let loggedInInfo;
   try {
-    loggedInInfo = childProcess.execFileSync('python', ['goma_auth.py', 'info'], {
+    loggedInInfo = depot.execFileSync(config, 'python', ['goma_auth.py', 'info'], {
       cwd: gomaDir,
       stdio: ['ignore'],
     });
@@ -143,12 +143,11 @@ function authenticateGoma(config) {
 
   downloadAndPrepareGoma(config);
 
-  if (!gomaIsAuthenticated()) {
+  if (!gomaIsAuthenticated(config)) {
     const { status, error } = depot.spawnSync(config, 'python', ['goma_auth.py', 'login'], {
       cwd: gomaDir,
       stdio: 'inherit',
       env: {
-        ...process.env,
         AGREE_NOTGOMA_TOS: '1',
       },
     });
@@ -191,11 +190,9 @@ function ensureGomaStart(config) {
     };
   }
 
-  console.log(color.childExec('goma_ctl.py', ['ensure_start'], { cwd: gomaDir }));
-  childProcess.execFileSync('python', ['goma_ctl.py', 'ensure_start'], {
+  depot.execFileSync(config, 'python', ['goma_ctl.py', 'ensure_start'], {
     cwd: gomaDir,
     env: {
-      ...process.env,
       ...gomaEnv(config),
       ...subprocs,
     },


### PR DESCRIPTION
Run all Goma commands (which use Python) through depot_tools. `python` doesn't exist on the latest macOS (only `python3`), but depot_tools still ships it.

This change actually kicks the Goma client back to using Python 2, but that's OK for the moment since there's some still a case in the client code where it's explicitly calling `python` anyway, which needs to be fixed for a true transition to Python 3.