### PR TITLE
chore: clear Goma last login time on log out

### DIFF
--- a/src/e
+++ b/src/e
@@ -265,6 +265,10 @@ program
       console.error(errorMsg);
     }
 
+    if (args.slice(0, 3).join(' ') === 'python goma_auth.py logout' && status === 0) {
+      goma.clearGomaLoginTime();
+    }
+
     process.exit(status);
   });
 

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -171,6 +171,11 @@ function getLastKnownLoginTime() {
   return new Date(parseInt(contents, 10));
 }
 
+function clearGomaLoginTime() {
+  if (!fs.existsSync(gomaLoginFile)) return;
+  fs.unlinkSync(gomaLoginFile);
+}
+
 function recordGomaLoginTime() {
   fs.writeFileSync(gomaLoginFile, `${Date.now()}`);
 }
@@ -244,5 +249,6 @@ module.exports = {
   downloadAndPrepare: downloadAndPrepareGoma,
   gnFilePath: gomaGnFile,
   env: gomaEnv,
+  clearGomaLoginTime,
   recordGomaLoginTime,
 };


### PR DESCRIPTION
Clear the last login time so that a subsequent `e build` will authenticate again, instead of waiting up to 12 hours.