### PR TITLE
fix: xcode parsing from CI config

### DIFF
--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -75,7 +75,7 @@ function getXcodeVersion() {
 }
 
 function extractXcodeVersion(config) {
-  const legacyMatch = /xcode: "(.+?)"/.exec(config);
+  const legacyMatch = /xcode: "?(\d+.\d+.\d+?)"?/.exec(config);
   if (legacyMatch) return legacyMatch;
   const modernMatch = /description: "xcode version"\n +default: ([^\n]+)\n/gm.exec(config);
   if (modernMatch) return modernMatch;


### PR DESCRIPTION
https://github.com/electron/electron/pull/33905 removed quotes from versions and https://github.com/electron/electron/pull/34850 removed the default config approach, leading to a failure to pick up version:
 
<img width="567" alt="Screen Shot 2022-07-19 at 10 00 01 AM" src="https://user-images.githubusercontent.com/2036040/179704090-ac71b3a0-1181-4a42-81a4-66c8426eaab3.png">

This fixes the associated regex.
 