### PR TITLE
fix: import required module to eliminate crash

### DIFF
--- a/src/utils/crbug.js
+++ b/src/utils/crbug.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const chrome = require('chrome-cookies-secure');
+const { color } = require('./logging');
 
 const BASE_URL = 'https://bugs.chromium.org';
 const GET_ISSUE = '/prpc/monorail.Issues/GetIssue';


### PR DESCRIPTION
When using `e cherry-pick --security`, if the process that fetches the associated CVE nr. fails, the error handling code crashes due to the usage of `color` without this module having been imported. This change fixes this by importing the `color` module.