### PR TITLE
fix: `e cherry-pick` adapt the bug nr. extraction regex for new variant

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -80,7 +80,8 @@ program
       const [, commitId] = /^From ([0-9a-f]+)/.exec(patch);
 
       const bugNumber =
-        (/^Bug: (.+)$/m.exec(patch) || [])[1] || (/^Bug= ?chromium:(.+)$/m.exec(patch) || [])[1];
+        (/^Bug[:=] ?(.+)$/im.exec(patch) || [])[1] ||
+        (/^Bug= ?chromium:(.+)$/m.exec(patch) || [])[1];
       const cve = security ? await getCveForBugNr(bugNumber.replace('chromium:', '')) : '';
 
       const commitMessage = /Subject: \[PATCH\] (.+?)^---$/ms.exec(patch)[1];


### PR DESCRIPTION
Addresses #412 .

Adapts the regex matching that is used to parse the bug nr. from Gerrit PRs descriptions, to account for a new variant in how the bug nr. is represented (see example in #412):
- Makes the matching case-insensitive.
- Drops the expectation that a bug nr. following "Bug=" contains the word "chromium".