### PR TITLE
feat: Use DEVELOPER_DIR to set Xcode path without requiring sudo

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -9,6 +9,7 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const { XcodePath } = require('./utils/xcode');
 
 function runGNGen(config) {
   depot.ensure();
@@ -85,6 +86,9 @@ program
         ? target === targets.chromium
         : targets.default === targets.chromium;
       if (process.platform === 'darwin' && !isChromium) {
+        // Setting DEVELOPER_DIR lets us override the Xcode path without requiring sudo
+        process.env.DEVELOPER_DIR = XcodePath;
+
         const result = depot.spawnSync(
           config,
           process.execPath,

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -9,7 +9,6 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
-const { XcodePath } = require('./utils/xcode');
 
 function runGNGen(config) {
   depot.ensure();
@@ -86,9 +85,6 @@ program
         ? target === targets.chromium
         : targets.default === targets.chromium;
       if (process.platform === 'darwin' && !isChromium) {
-        // Setting DEVELOPER_DIR lets us override the Xcode path without requiring sudo
-        process.env.DEVELOPER_DIR = XcodePath;
-
         const result = depot.spawnSync(
           config,
           process.execPath,

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -75,6 +75,8 @@ function depotOpts(config, opts = {}) {
     // set these defaults that can be overridden via process.env
     PYTHONDONTWRITEBYTECODE: '1', // depot needs it
     DEPOT_TOOLS_METRICS: '0', // disable depot metrics
+    // Circular reference so we have to delay load
+    DEVELOPER_DIR: require('./xcode').XcodePath, // use build-tools version of Xcode
     ...process.env,
     ...platformOpts(),
     ...config.env,


### PR DESCRIPTION
When you work on multiple projects with different Xcode versions, having `e build` invoke `sudo xcode-select -s` all the time get's annoying.

By setting `DEVELOPER_DIR` in `e-build.js` before calling `e-load-xcode.js`, we make `xcode-select -p` return the correct Xcode path, so `e-load-xcode.js` won't attempt to `xcode-select -s` as sudo. Subsequent subprocess calls to actually build Electron will also pick up that `DEVELOPER_DIR` variable, ensuring that the right Xcode version is used.

```
$ xcode-select -p
/Applications/Xcode.app/Contents/Developer

$ e build
Running "e load-xcode --quiet"
Running "ninja -j 200 electron" in /Users/<user>/electron/master/src/out/Testing
[21/21] STAMP obj/electron/electron.stamp
```

If you actually want to persist the selection change, you can still call `e load-xcode` directly.

```
 $ xcode-select -p
/Applications/Xcode.app/Contents/Developer

$ e load-xcode
Setting your Xcode installation to /Users/<user>/.electron_build_tools/third_party/Xcode/Xcode.app, this will require sudo
Password:
SUCCESS

$ xcode-select -p
/Users/<user>/.electron_build_tools/third_party/Xcode/Xcode.app/Contents/Developer
```

Fixes #416

