### PR TITLE
chore: remove unused remotes.node in config

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -40,18 +40,11 @@ function createConfig(options) {
     }),
   };
 
-  const node = {
-    origin: options.useHttps
-      ? 'https://github.com/electron/node.git'
-      : 'git@github.com:electron/node.git',
-  };
-
   return {
     goma: options.goma,
     root,
     remotes: {
       electron,
-      node,
     },
     gen: {
       args: gn_args,

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -58,10 +58,8 @@ function runGClientSync(syncArgs, syncOpts) {
   // Only set remotes if we're building an Electron target.
   if (config.defaultTarget !== evmConfig.buildTargets.chromium) {
     const electronPath = path.resolve(srcdir, 'electron');
-    const nodejsPath = path.resolve(srcdir, 'third_party', 'electron_node');
 
     setRemotes(electronPath, config.remotes.electron);
-    setRemotes(nodejsPath, config.remotes.node);
   }
 }
 

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -175,13 +175,13 @@ function sanitizeConfig(name, overwrite = false) {
       electron: {
         origin: config.origin.electron,
       },
-      node: {
-        origin: config.origin.node,
-      },
     };
 
     delete config.origin;
     changes.push(`replaced superceded 'origin' property with 'remotes' property`);
+  } else if (config.remotes?.node) {
+    delete config.remotes.node;
+    changes.push(`removed deprecated ${color.config('remotes.node')} property`);
   }
 
   if (

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -179,7 +179,7 @@ function sanitizeConfig(name, overwrite = false) {
 
     delete config.origin;
     changes.push(`replaced superceded 'origin' property with 'remotes' property`);
-  } else if (config.remotes?.node) {
+  } else if (config.remotes && config.remotes.node) {
     delete config.remotes.node;
     changes.push(`removed deprecated ${color.config('remotes.node')} property`);
   }

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -57,7 +57,7 @@ describe('e-init', () => {
       expect(config.goma).toStrictEqual('cache-only');
 
       expect(config.remotes).toHaveProperty('electron');
-      expect(config.remotes).toHaveProperty('node');
+      expect(config.remotes).not.toHaveProperty('node');
 
       const remotes = config.remotes.electron;
       expect(remotes.origin).toStrictEqual('https://github.com/electron/electron.git');


### PR DESCRIPTION
This stopped being used a while ago at this point, but it's still in the code base, and changes the remote for `src/third_party/electron_node` in an Electron checkout when it probably shouldn't.