### PR TITLE
ci: use lts/-1 with actions/setup-node

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,10 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
     - uses: actions/checkout@v1
-    - name: Use Node.js v12.x
-      uses: actions/setup-node@v1
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
       with:
-        node-version: 12.x
+        node-version: lts/-1
     - name: Cache node_modules
       id: cache-node-modules
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - name: Use Node.js v14.x
-      uses: actions/setup-node@v1
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: lts/-1
     - name: Cache node_modules
       id: cache-node-modules
       uses: actions/cache@v2

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "build-tools",
   "version": "0.2.0",
   "engines": {
-    "node": ">= 12.20.0"
+    "node": ">= 14.0.0"
   },
   "main": "null",
   "private": true,


### PR DESCRIPTION
v12 is no longer supported, and I want that sweet, sweet optional chaining.