### PR TITLE
refactor: don't run getDefaultTarget on module load

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -71,7 +71,7 @@ program
   .action((target, ninjaArgs, options) => {
     try {
       const config = evmConfig.current();
-      const targets = evmConfig.buildTargets;
+      const targets = evmConfig.buildTargets();
 
       if (options.listTargets) {
         Object.keys(targets)

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -56,7 +56,7 @@ function runGClientSync(syncArgs, syncOpts) {
   depot.spawnSync(config, exec, args, opts);
 
   // Only set remotes if we're building an Electron target.
-  if (config.defaultTarget !== evmConfig.buildTargets.chromium) {
+  if (config.defaultTarget !== evmConfig.buildTargets().chromium) {
     const electronPath = path.resolve(srcdir, 'electron');
     const nodejsPath = path.resolve(srcdir, 'third_party', 'electron_node');
 

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -25,7 +25,7 @@ const getDefaultTarget = () => {
   return result || 'electron';
 };
 
-const buildTargets = {
+const buildTargets = () => ({
   breakpad: 'third_party/breakpad:dump_syms',
   chromedriver: 'electron:electron_chromedriver_zip',
   electron: 'electron',
@@ -34,7 +34,7 @@ const buildTargets = {
   mksnapshot: 'electron:electron_mksnapshot_zip',
   'node:headers': 'third_party/electron_node:headers',
   default: getDefaultTarget(),
-};
+});
 
 function buildPath(name, suffix) {
   return path.resolve(configRoot, `evm.${name}.${suffix}`);


### PR DESCRIPTION
`getDefaultTarget` will trigger a sanitize on the config, leading to the undesirable behavior that `e sanitize-config` will sanitize (and output any problems) twice.