### PR TITLE
build: use the goma local cache by default on init

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -55,6 +55,10 @@ function createConfig(options) {
       GIT_CACHE_PATH: process.env.GIT_CACHE_PATH
         ? resolvePath(process.env.GIT_CACHE_PATH)
         : path.resolve(homedir, '.git_cache'),
+      GOMA_CACHE_DIR: path.resolve(homedir, '.goma_cache'),
+      GOMA_DEPS_CACHE_FILE: 'deps-cache',
+      GOMA_COMPILER_INFO_CACHE_FILE: 'compiler-info-cache',
+      GOMA_LOCAL_OUTPUT_CACHE_DIR: path.resolve(homedir, '.gome_output_cache'),
     },
   };
 }

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -194,7 +194,9 @@ function sanitizeConfig(name, overwrite = false) {
     changes.push(`removed ${color.config('cc_wrapper')} definition because goma is enabled`);
   }
 
-  if (!config.env || !config.env.CHROMIUM_BUILDTOOLS_PATH) {
+  if (!config.env) config.env = {};
+
+  if (!config.env.CHROMIUM_BUILDTOOLS_PATH) {
     const toolsPath = path.resolve(config.root, 'src', 'buildtools');
     config.env.CHROMIUM_BUILDTOOLS_PATH = toolsPath;
     changes.push(`defined ${color.config('CHROMIUM_BUILDTOOLS_PATH')}`);


### PR DESCRIPTION
This speeds up by rebuilds from 8 mintues to 6 minutes on my M1 at least 🤷 seems to be free to enable (only costs local disk space).  Should also reduce load on our clusters from actual devs.