### PR TITLE
fix: allow overriding `DEVELOPER_DIR`

### DIFF
--- a/src/e-load-xcode.js
+++ b/src/e-load-xcode.js
@@ -18,12 +18,17 @@ if (Xcode.ensureXcode() === false) {
 // Select our new xcode
 const output = childProcess.execFileSync('xcode-select', ['-p']).toString();
 if (!output.trim().startsWith(Xcode.XcodePath)) {
-  console.info(
-    `Setting your Xcode installation to ${color.path(Xcode.XcodePath)}, this will require sudo`,
-  );
-  childProcess.execFileSync('sudo', ['xcode-select', '-s', Xcode.XcodePath], {
-    stdio: 'inherit',
-  });
+  if (process.env.DEVELOPER_DIR.length) {
+    console.info(`${color.info} Using overridden Xcode at ${process.env.DEVELOPER_DIR}`);
+    return;
+  } else {
+    console.info(
+      `Setting your Xcode installation to ${color.path(Xcode.XcodePath)}, this will require sudo`,
+    );
+    childProcess.execFileSync('sudo', ['xcode-select', '-s', Xcode.XcodePath], {
+      stdio: 'inherit',
+    });
+  }
 }
 
 // Ensure that we have accepted the Xcode license agreement

--- a/src/e-load-xcode.js
+++ b/src/e-load-xcode.js
@@ -18,7 +18,7 @@ if (Xcode.ensureXcode() === false) {
 // Select our new xcode
 const output = childProcess.execFileSync('xcode-select', ['-p']).toString();
 if (!output.trim().startsWith(Xcode.XcodePath)) {
-  if (process.env.DEVELOPER_DIR.length) {
+  if (process.env.DEVELOPER_DIR) {
     console.info(`${color.info} Using overridden Xcode at ${process.env.DEVELOPER_DIR}`);
     return;
   } else {


### PR DESCRIPTION
Allow users to override `DEVELOPER_DIR`.

Previously, if `DEVELOPER_DIR` was overridden, `e load-xcode` would try to switch it back every time.