### PR TITLE
feat: add `e shell` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,18 @@ $ e sanitize-config --help
 
 Sometimes `build-tools` will make updates to its config requirements. In these events warnings will be output to console to inform you that `build-tools` has temporarily handled the issues. You can make these warnings go away either by manually updating your config files or by running this command to automatically overwrite the existing configs to update formatting.
 
+### `e shell`
+
+`e shell` launches a shell environment populated with build-tools' environment variables and context.
+
+Developers may for example find themselves wishing to access `gn` and `ninja` directly - instead of using `e d gn` to access that this command can be used. This also enables bash completion and the ability to copy-paste commands from Chromium docs without modification.
+
+```sh
+$ e shell
+# Launching build-tools shell with "/bin/zsh"
+# Running "/bin/zsh"
+```
+
 ## Common Usage
 
 ### Building a Specific Electron Version

--- a/src/e
+++ b/src/e
@@ -279,6 +279,33 @@ program
     process.exit(0);
   });
 
+program
+  .command('shell')
+  .description(
+    "Launch a shell environment populated with build-tools' environment variables and context",
+  )
+  .action(() => {
+    depot.ensure();
+
+    if (!['linux', 'darwin'].includes(process.platform)) {
+      fatal(`'e shell' is not supported on non-unix platforms`);
+    }
+
+    if (!process.env.SHELL) {
+      fatal('Could not detect shell to launch');
+    }
+
+    console.info(`Launching build-tools shell with ${color.cmd(process.env.SHELL)}`);
+    const { status } = depot.spawnSync(evmConfig.current(), process.env.SHELL, [], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        SHELL_CONTEXT: evmConfig.currentName(),
+      },
+    });
+    process.exit(status);
+  });
+
 program.on('--help', () => {
   console.log(`
 See https://github.com/electron/build-tools/blob/main/README.md for usage.`);


### PR DESCRIPTION
This command spawns your current shell with all the environment variables that build-tools normally uses fully in your environment.  Sometimes I find myself running `e d {thing}` a _lot_ and it's annoying not having things like bash completion or the ability to copy paste commands from chromium docs.

This fixes that by spawning a temporary populated shell with everything you need to run things like `ninja` and `gn` directly.  The extra env var is for folks like me who want to be able to customize their shell prompt when running in this mode, see below for an example.

![image](https://user-images.githubusercontent.com/6634592/203525557-bc117e6b-7425-4cdf-8a70-042f5f2928a7.png)

I was doing this locally with an alias `SHELL_CONTEXT=" $(e show current)" e d $SHELL` but figured other folks might benefit from it