### PR TITLE
fix: goma login on modern python windows

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -107,6 +107,9 @@ function depotOpts(config, opts = {}) {
 
 function depotSpawnSync(config, cmd, args, opts_in) {
   const opts = depotOpts(config, opts_in);
+  if (os.platform() === 'win32' && ['python', 'python3'].includes(cmd)) {
+    cmd = `${cmd}.bat`;
+  }
   if (opts_in.msg) {
     console.log(opts_in.msg);
   } else {


### PR DESCRIPTION
While setting up my new Windows laptop, I ran into an error with goma where the `info` command was calling the `python3.bat` file in depot tools, but the `login` command was incorrectly calling just `python3` which is not anywhere in the path on the latest version of Python (3.11) on windows.

This PR follows the same fix as done a little bit below in `depotExecFileSync`: just append `.bat` if the command is `python` or `python3`.