### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*       @ckerr @MarshallOfSound @codebytere @jkleinsc
+* @electron/wg-infra
+* @ckerr


### PR DESCRIPTION
@/electron/wg-infra formally owns this repo now, so reflect that in `CODEOWNERS`.