### PR TITLE
fix: use ninja.bat on Windows

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -51,7 +51,7 @@ function runNinja(config, target, useGoma, ninjaArgs) {
   depot.ensure(config);
   ensureGNGen(config);
 
-  const exec = os.platform() === 'win32' ? 'ninja.exe' : 'ninja';
+  const exec = os.platform() === 'win32' ? 'ninja.bat' : 'ninja';
   const args = [...ninjaArgs, target];
   const opts = {
     cwd: evmConfig.outDir(config),


### PR DESCRIPTION
Looks like `ninja.exe` was removed in [the commit that dropped ninja binaries](https://chromium.googlesource.com/chromium/tools/depot_tools/+/8f41177abf2c51b2c0114af9abe9a5cd074d5014). `ninja.bat` was added in Nov 2022.