### PR TITLE
fix: Appveyor status  display

### DIFF
--- a/src/ci/ci-status.js
+++ b/src/ci/ci-status.js
@@ -37,12 +37,23 @@ const colorForStatus = status => {
   }
 };
 
-const getStatusString = check => {
+const getCircleStatusString = check => {
   return check.status === 'completed'
     ? check.conclusion === 'success'
       ? chalk.green('success')
       : chalk.redBright('failed')
     : chalk.yellow('running');
+};
+
+const getAppveyorStatusString = check => {
+  switch (check.state) {
+    case 'success':
+      return chalk.green('success');
+    case 'failure':
+      return chalk.redBright('failed');
+    default:
+      return chalk.yellow('running');
+  }
 };
 
 const formatLink = (name, url) => `\x1B]8;;${url}\x1B\\${name}\x1B]8;;\x1B\\`;
@@ -60,7 +71,8 @@ const printChecks = (checks, link) => {
       result += `  ⦿ ${name} - ${chalk.blue('Missing')}\n`;
       continue;
     }
-    const status = getStatusString(check);
+
+    const status = getCircleStatusString(check);
     const url = new URL(check.details_url);
 
     if (link) {
@@ -102,7 +114,8 @@ const printStatuses = (statuses, link) => {
       result += `  ⦿ ${chalk.bold(name)} - ${chalk.blue('Missing')}\n\n`;
       continue;
     }
-    const status = getStatusString(check);
+
+    const status = getAppveyorStatusString(check);
     const url = new URL(check.target_url);
 
     if (link) {


### PR DESCRIPTION
Fixes an issue where Appveyor status strings were incorrectly parsed and always displayed `running`.

<details><summary>Before:</summary>

```
electron on git:roller/chromium/main ❯ e ci status                       12:36PM
Electron CI Status
  Ref: roller/chromium/main

  Circle CI
  ⦿ macOS - success - cee1d546-3aaf-4a69-8601-3e89e6a77806

  ⦿ Linux - success - c85f8742-505c-4d01-880d-03344b510d1f

  ⦿ Lint - success - f12e8ce8-78f4-4c91-8ea7-9658ff2fa822


  Appveyor
  ⦿ Windows x64 - running - 46084066

  ⦿ Windows x64 (PR) - Missing

  ⦿ Windows ia32 - running - 46084053

  ⦿ Windows ia32 (PR) - Missing

  ⦿ Windows Arm - running - 46084060
```

</details>

<details><summary>After:</summary>

```
electron on git:roller/chromium/main ❯ e ci status                       12:35PM
Electron CI Status
  Ref: roller/chromium/main

  Circle CI
  ⦿ macOS - success - cee1d546-3aaf-4a69-8601-3e89e6a77806

  ⦿ Linux - success - c85f8742-505c-4d01-880d-03344b510d1f

  ⦿ Lint - success - f12e8ce8-78f4-4c91-8ea7-9658ff2fa822


  Appveyor
  ⦿ Windows x64 - failed - 46084066

  ⦿ Windows x64 (PR) - Missing

  ⦿ Windows ia32 - failed - 46084053

  ⦿ Windows ia32 (PR) - Missing

  ⦿ Windows Arm - failed - 46084060
```

</details>