### PR TITLE
chore: fix name of .goma_output_cache directory

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -58,7 +58,7 @@ function createConfig(options) {
       GOMA_CACHE_DIR: path.resolve(homedir, '.goma_cache'),
       GOMA_DEPS_CACHE_FILE: 'deps-cache',
       GOMA_COMPILER_INFO_CACHE_FILE: 'compiler-info-cache',
-      GOMA_LOCAL_OUTPUT_CACHE_DIR: path.resolve(homedir, '.gome_output_cache'),
+      GOMA_LOCAL_OUTPUT_CACHE_DIR: path.resolve(homedir, '.goma_output_cache'),
     },
   };
 }


### PR DESCRIPTION
[Pointed out](https://github.com/electron/build-tools/commit/bc30071c8ce985c7c32e630677923a599479ecd5#r90654386) by @nornagon, but didn't get fixed before merge.