### PR TITLE
chore: check for error when downloading Goma/Xcode

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -87,13 +87,17 @@ function downloadAndPrepareGoma(config) {
 
   const downloadURL = `${gomaBaseURL}/${sha}/${filename}`;
   console.log(`Downloading ${color.cmd(downloadURL)} into ${color.path(tmpDownload)}`);
-  childProcess.spawnSync(
+  const { status } = childProcess.spawnSync(
     process.execPath,
     [path.resolve(__dirname, '..', 'download.js'), downloadURL, tmpDownload],
     {
       stdio: 'inherit',
     },
   );
+  if (status !== 0) {
+    rimraf.sync(tmpDownload);
+    fatal(`Failure while downloading goma`);
+  }
   const hash = crypto
     .createHash('SHA256')
     .update(fs.readFileSync(tmpDownload))

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -180,13 +180,18 @@ function ensureXcode() {
       if (shouldDownload) {
         const XcodeURL = `${XcodeBaseURL}${XcodeVersions[expected].fileName}`;
         console.log(`Downloading ${color.cmd(XcodeURL)} into ${color.path(XcodeZip)}`);
-        cp.spawnSync(
+        const { status } = cp.spawnSync(
           process.execPath,
           [path.resolve(__dirname, '..', 'download.js'), XcodeURL, XcodeZip],
           {
             stdio: 'inherit',
           },
         );
+
+        if (status !== 0) {
+          rimraf.sync(XcodeZip);
+          fatal(`Failure while downloading Xcode zip`);
+        }
 
         const newHash = hashFile(XcodeZip);
         if (newHash !== expectedXcodeHash) {


### PR DESCRIPTION
The hash check catches these more or less, but better to be explicit.