### PR TITLE
fix: build node headers without goma when disabled in config

### DIFF
--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -24,6 +24,8 @@ function ensureNodeHeaders(config) {
   if (needs_build) {
     const exec = process.execPath;
     const args = [path.resolve(__dirname, '..', 'e'), 'build', 'node:headers'];
+    if (config.goma === 'none') args.push('--no-goma');
+
     const opts = { stdio: 'inherit', encoding: 'utf8' };
     childProcess.execFileSync(exec, args, opts);
   }


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/465.