### PR TITLE
refactor: use goma flag in e test

### DIFF
--- a/src/e-test.js
+++ b/src/e-test.js
@@ -38,6 +38,7 @@ program
   .allowUnknownOption()
   .option('--node', 'Run node spec runner', false)
   .option('--nan', 'Run nan spec runner', false)
+  .option('--no-goma', 'Build test runner components (e.g. node:headers) without goma')
   .option(
     '--runners=<main|remote|native>',
     "A subset of tests to run - either 'main', 'remote', or 'native', not used with either the node or nan specs",
@@ -57,7 +58,7 @@ program
       if (options.nan) {
         script = './script/nan-spec-runner.js';
       }
-      ensureNodeHeaders(config);
+      ensureNodeHeaders(config, options.goma);
       runSpecRunner(config, script, specRunnerArgs);
     } catch (e) {
       fatal(e);

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -5,7 +5,7 @@ const path = require('path');
 const evmConfig = require('../evm-config');
 const { ensureDir } = require('./paths');
 
-function ensureNodeHeaders(config) {
+function ensureNodeHeaders(config, useGoma) {
   const src_dir = path.resolve(config.root, 'src');
   const out_dir = evmConfig.outDir(config);
   const node_headers_dir = path.resolve(out_dir, 'gen', 'node_headers');
@@ -24,7 +24,7 @@ function ensureNodeHeaders(config) {
   if (needs_build) {
     const exec = process.execPath;
     const args = [path.resolve(__dirname, '..', 'e'), 'build', 'node:headers'];
-    if (config.goma === 'none') args.push('--no-goma');
+    if (!useGoma) args.push('--no-goma');
 
     const opts = { stdio: 'inherit', encoding: 'utf8' };
     childProcess.execFileSync(exec, args, opts);


### PR DESCRIPTION
`e build` takes config into account - on second thought I believe there are situations were one would want to build test components without goma yet have goma enabled in their config. Let's enable that use case instead.