### PR TITLE
feat: add $schema to configs

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -3,6 +3,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
     "defaultTarget": {
       "description": "Default build target",
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "path-key": "^3.1.0",
     "progress": "^2.0.3",
     "readline-sync": "^1.4.10",
+    "vscode-uri": "^3.0.7",
     "which": "^2.0.2"
   },
   "devDependencies": {

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -5,6 +5,7 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const { program, Option } = require('commander');
+const { URI } = require('vscode-uri');
 
 const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
@@ -49,7 +50,7 @@ function createConfig(options) {
   };
 
   return {
-    $schema: path.resolve(__dirname, '..', 'evm-config.schema.json'),
+    $schema: URI.file(path.resolve(__dirname, '..', 'evm-config.schema.json')).toString(),
     goma: options.goma,
     root,
     remotes: {

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -49,6 +49,7 @@ function createConfig(options) {
   };
 
   return {
+    $schema: path.resolve(__dirname, '..', 'evm-config.schema.json'),
     goma: options.goma,
     root,
     remotes: {

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -4,6 +4,7 @@ const os = require('os');
 const path = require('path');
 const Ajv = require('ajv');
 const yml = require('js-yaml');
+const { URI } = require('vscode-uri');
 const { color, fatal } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const goma = require('./utils/goma');
@@ -168,7 +169,7 @@ function sanitizeConfig(name, overwrite = false) {
   const changes = [];
 
   if (!('$schema' in config)) {
-    config.$schema = path.resolve(__dirname, '..', 'evm-config.schema.json');
+    config.$schema = URI.file(path.resolve(__dirname, '..', 'evm-config.schema.json')).toString();
     changes.push(`added missing property ${color.config('$schema')}`);
   }
 

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -167,6 +167,11 @@ function sanitizeConfig(name, overwrite = false) {
   const config = loadConfigFileRaw(name);
   const changes = [];
 
+  if (!('$schema' in config)) {
+    config.$schema = path.resolve(__dirname, '..', 'evm-config.schema.json');
+    changes.push(`added missing property ${color.config('$schema')}`);
+  }
+
   if (!['none', 'cluster', 'cache-only'].includes(config.goma)) {
     config.goma = 'cache-only';
     changes.push(`added missing property ${color.config('goma: cache-only')}`);

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -56,6 +56,7 @@ describe('e-init', () => {
       expect(fs.existsSync(configPath)).toStrictEqual(true);
 
       const config = require(configPath);
+      expect(config).toHaveProperty('$schema');
       expect(config.goma).toStrictEqual('cache-only');
 
       expect(config.remotes).toHaveProperty('electron');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5361,6 +5361,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vscode-uri@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.7.tgz#6d19fef387ee6b46c479e5fb00870e15e58c1eb8"
+  integrity sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==
+
 w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"


### PR DESCRIPTION
Small but interesting change to add `$schema` to configs, referencing the schema on disk. Gets automatic editor support for the config schema in editors that support it like VS Code, and I can drop my duplicate copy of the schema from my VS Code extension. Will otherwise be a no-op.