### PR TITLE
chore: fix lint

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -57,7 +57,7 @@ function platformOpts() {
         GYP_MSVS_HASH_3bda71a11e: 'e146e01913',
         GYP_MSVS_HASH_e41785f09f: 'e146e01913',
         GYP_MSVS_HASH_1023ce2e82: '3a908a0f94',
-        GYP_MSVS_HASH_27370823e7: '28622d16b1'
+        GYP_MSVS_HASH_27370823e7: '28622d16b1',
       };
   }
 


### PR DESCRIPTION
bb70188125f3f0bf21cab1c28a678b4c6b7746af fails lint due to the lack of a trailing comma.