### PR TITLE
chore: document --electronVersion option for test runner

### DIFF
--- a/src/e-test.js
+++ b/src/e-test.js
@@ -36,6 +36,7 @@ function runSpecRunner(config, script, runnerArgs) {
 program
   .argument('[specRunnerArgs...]')
   .allowUnknownOption()
+  .option('--electronVersion <version>', 'Electron release to run tests against')
   .option('--node', 'Run node spec runner', false)
   .option('--nan', 'Run nan spec runner', false)
   .option('--no-goma', 'Build test runner components (e.g. node:headers) without goma')
@@ -50,6 +51,9 @@ program
         fatal(
           'Can not run both node and nan specs at the same time, --node and --nan are mutually exclusive',
         );
+      }
+      if (options.electronVersion) {
+        specRunnerArgs.push(`--electronVersion=${options.electronVersion}`);
       }
       let script = './script/spec-runner.js';
       if (options.node) {


### PR DESCRIPTION
Support for this was added in `e/e` in https://github.com/electron/electron/pull/36944, but the `spec-runner.js` script doesn't have any kind of help output so there's no way to discover that the option is available.

Document it here in the same way that we document the `--runners` option, and just pass it through as-is.