### PR TITLE
fix: run yarn install on branch in `e backport`

### DIFF
--- a/src/e-backport.js
+++ b/src/e-backport.js
@@ -90,6 +90,12 @@ program
       return;
     }
 
+    const yarnInstallResult = spawnSync(config, 'yarn', ['install'], gitOpts);
+    if (yarnInstallResult.status !== 0) {
+      fatal(`Failed to do "yarn install" on new branch`);
+      return;
+    }
+
     spawnSync(config, 'git', ['cherry-pick', pr.merge_commit_sha], {
       cwd: gitOpts.cwd,
     });


### PR DESCRIPTION
Switching branches may cause pre-commit hooks to fail if you don't do a `yarn install` on the branch.