### PR TITLE
chore: improve final commands output for `e backport`

### DIFF
--- a/src/e-backport.js
+++ b/src/e-backport.js
@@ -94,13 +94,15 @@ program
       cwd: gitOpts.cwd,
     });
 
+    const isFork = !!config.remotes.electron.fork;
+
     console.info(
       '\n',
       chalk.cyan(
         `Cherry pick complete, fix conflicts locally and then run the following commands "${chalk.yellow(
           'git cherry-pick --continue',
-        )}", "${chalk.yellow('git push')}" and finally "${chalk.yellow(
-          'e pr',
+        )}", "${chalk.yellow(isFork ? 'git push fork' : 'git push')}" and finally "${chalk.yellow(
+          `e pr --backport ${prNumber}`,
         )}" to create your new pull request`,
       ),
     );


### PR DESCRIPTION
Makes the commands accurate. Pushing to your fork (even if you have write access to `e/e`) is important since `e pr` expects the branch to be on your fork if your config uses one.