### PR TITLE
fix: JSON schema Chromium compatibility

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -16,7 +16,8 @@
         "electron",
         "electron:dist",
         "mksnapshot",
-        "node:headers"
+        "node:headers",
+        "chrome"
       ]
     },
     "extends": {
@@ -141,6 +142,19 @@
     {
       "required": [
         "extends"
+      ]
+    },
+    {
+      "properties": {
+        "defaultTarget": {
+          "type": "string",
+          "pattern": "chrome"
+        }
+      },
+      "required": [
+        "defaultTarget",
+        "env",
+        "root"
       ]
     },
     {

--- a/example-configs/evm.chromium.yml
+++ b/example-configs/evm.chromium.yml
@@ -1,15 +1,11 @@
-root: /path/to/your/developer/folder
-remotes:
-  electron:
-    # SSH or HTTPS url
-    # ssh: git@github.com:electron/electron.git
-    # https: https://github.com/electron/electron
-    origin: git@github.com:electron/electron.git
+root: /path/to/chromium/
+defaultTarget: chrome
 gen:
   args:
     # path to goma for faster builds (https://notgoma.com)
     - import("/Users/user_name/.electron_build_tools/third_party/goma.gn")
-  out: Testing
+    - is_debug = false
+  out: Default
 env:
   GIT_CACHE_PATH: /Users/user_name/.git_cache
   CHROMIUM_BUILDTOOLS_PATH: /path/to/your/developer/folder/src/build-tools


### PR DESCRIPTION
The JSON Schema added in https://github.com/electron/build-tools/issues/421 doesn't take into account a user looking to build Chromium itself.

This fixes that by adding an exception for the required schema objects if the `defaultTarget` is `chrome`.