### PR TITLE
fix: handle missing `yarn` during auto-update

### DIFF
--- a/src/e-auto-update.js
+++ b/src/e-auto-update.js
@@ -68,7 +68,7 @@ function checkForUpdates() {
       globalNodeModulesPaths.push(
         path.join(
           cp
-            .execSync('yarn global dir')
+            .execSync('npx yarn global dir')
             .toString('utf8')
             .trim(),
           'node_modules',


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/414.

Corrects the following error seen in console during auto-update:

```
codebytere@CODEBYTERE-WIN-WORK MINGW64 ~/Developer/electron-gn/src/electron (main)
$ e 
Checking for build-tools updates
'yarn' is not recognized as an internal or external command,
operable program or batch file.
```