### PR TITLE
ci: remove obsolete goma option

### DIFF
--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -215,21 +215,6 @@ function ensureGomaStart(config) {
   });
 }
 
-function gomaAuthFailureEnv(config) {
-  let isCacheOnly = config && config.goma === 'cache-only';
-  if (!config) {
-    // If no config is provided we are running in CI, infer cache-only from the presence
-    // of the RAW_GOMA_AUTH env var
-    isCacheOnly = !process.env.RAW_GOMA_AUTH;
-  }
-  if (isCacheOnly) {
-    return {
-      GOMA_FALLBACK_ON_AUTH_FAILURE: 'true',
-    };
-  }
-  return {};
-}
-
 function gomaCIEnv(config) {
   if (!config && process.env.CI) {
     return {
@@ -242,7 +227,6 @@ function gomaCIEnv(config) {
 
 function gomaEnv(config) {
   return {
-    ...gomaAuthFailureEnv(config),
     ...gomaCIEnv(config),
   };
 }


### PR DESCRIPTION
`GOMA_FALLBACK_ON_AUTH_FAILURE` is no longer a valid goma client option and is causing errors running gclient