### PR TITLE
chore: log info message when auto-update disabled

### DIFF
--- a/src/e
+++ b/src/e
@@ -19,6 +19,7 @@ function maybeCheckForUpdates() {
   // skip auto-update check if disabled
   const disableAutoUpdatesFile = path.resolve(__dirname, '..', '.disable-auto-updates');
   if (fs.existsSync(disableAutoUpdatesFile)) {
+    console.info(`${color.info} Auto-updates disabled, skipping check for updates`);
     return;
   }
   // don't check if we already checked recently


### PR DESCRIPTION
Useful for when you forget that you turned off auto-update in the past.