### PR TITLE
chore: skip ensure Node headers in `e test` with --electronVersion

### DIFF
--- a/src/e-test.js
+++ b/src/e-test.js
@@ -67,7 +67,9 @@ program
       if (options.nan) {
         script = './script/nan-spec-runner.js';
       }
-      ensureNodeHeaders(config, options.goma);
+      if (!options.electronVersion) {
+        ensureNodeHeaders(config, options.goma);
+      }
       runSpecRunner(config, script, specRunnerArgs);
     } catch (e) {
       fatal(e);


### PR DESCRIPTION
Since an aim of `--electronVersion` is to allow running tests without doing a local build, skip ensuring Node headers exist locally.