### PR TITLE
fix: disable login when goma is `cache-only`

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -69,6 +69,7 @@ function createConfig(options) {
       GOMA_DEPS_CACHE_FILE: 'deps-cache',
       GOMA_COMPILER_INFO_CACHE_FILE: 'compiler-info-cache',
       GOMA_LOCAL_OUTPUT_CACHE_DIR: path.resolve(homedir, '.goma_output_cache'),
+      ...(options.goma !== 'cluster' && { GOMACTL_SKIP_AUTH: 'true' }),
     },
   };
 }

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -129,7 +129,6 @@ function downloadAndPrepareGoma(config) {
 }
 
 function gomaIsAuthenticated(config) {
-  if (!isSupportedPlatform) return false;
   const lastKnownLogin = getLastKnownLoginTime();
   // Assume if we authed in the last 12 hours it is still valid
   if (lastKnownLogin && Date.now() - lastKnownLogin.getTime() < 1000 * 60 * 60 * 12) return true;
@@ -144,8 +143,7 @@ function gomaIsAuthenticated(config) {
     return false;
   }
 
-  const loggedInPattern = /^Login as (\w+\s\w+)$/;
-  return loggedInPattern.test(loggedInInfo.toString().trim());
+  return /^Login as (\w+\s\w+)$/.test(loggedInInfo.toString().trim());
 }
 
 function authenticateGoma(config) {
@@ -197,7 +195,7 @@ function ensureGomaStart(config) {
   // Set number of subprocs to equal number of CPUs for MacOS
   let subprocs = {};
   if (process.platform === 'darwin') {
-    const cpus = os.cpus().length;
+    const { length: cpus } = os.cpus();
     subprocs = {
       GOMA_MAX_SUBPROCS: cpus.toString(),
       GOMA_MAX_SUBPROCS_LOW: cpus.toString(),
@@ -232,7 +230,6 @@ function gomaEnv(config) {
 }
 
 module.exports = {
-  isAuthenticated: gomaIsAuthenticated,
   auth: authenticateGoma,
   ensure: ensureGomaStart,
   dir: gomaDir,


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/501.

Fixes an issue where goma would try to perform login when the user was not in cluster mode. Also cleans up some authentication logic and removes an unused export.

<details><summary>Relevant Goma Logic</summary>
<p>

<img width="685" alt="Screenshot 2023-07-26 at 2 32 26 PM" src="https://github.com/electron/build-tools/assets/2036040/110ea252-f3a4-43f2-95a0-c382906a46fe">

</p>
</details> 