### PR TITLE
refactor: use gh auth token instead of parsing gh auth status

### DIFF
--- a/src/utils/github-auth.js
+++ b/src/utils/github-auth.js
@@ -1,26 +1,13 @@
-const { spawn } = require('child_process');
+const { spawnSync } = require('child_process');
 const { createOAuthDeviceAuth } = require('@octokit/auth-oauth-device');
 
 const ELECTRON_BUILD_TOOLS_GITHUB_CLIENT_ID = '03581ca0d21228704ab3';
 
 async function getGitHubAuthToken(scopes = []) {
   try {
-    const gh = spawn('gh', ['auth', 'status', '--show-token']);
-    const done = new Promise((resolve, reject) => {
-      gh.on('close', resolve);
-      gh.on('error', reject);
-    });
-    const stderrChunks = [];
-    gh.stderr.on('data', chunk => stderrChunks.push(chunk));
-    const exitCode = await done;
-    if (exitCode === 0) {
-      const stderr = Buffer.concat(stderrChunks).toString('utf8');
-      const m = /Token: (.+)$/m.exec(stderr);
-      if (m) {
-        return m[1];
-      }
-    }
-  } catch (e) {
+    const { stdout } = spawnSync('gh', ['auth', 'token'], { encoding: 'utf8' });
+    return stdout.trim();
+  } catch {
     // fall through to fetching the token through oauth
   }
   const auth = createOAuthDeviceAuth({


### PR DESCRIPTION
The `gh auth token` command was added a while back in https://github.com/cli/cli/pull/6324, so use that to simplify this code.