### PR TITLE
refactor: check GH auth token env var in getGitHubAuthToken

### DIFF
--- a/src/ci/ci-status.js
+++ b/src/ci/ci-status.js
@@ -209,7 +209,7 @@ program
       .trim();
 
     const octokit = new Octokit({
-      auth: process.env.ELECTRON_BUILD_TOOLS_GH_AUTH || (await getGitHubAuthToken(['repo'])),
+      auth: await getGitHubAuthToken(['repo']),
     });
 
     const ref = options.ref ? parseRef(options.ref) : currentRef;

--- a/src/e-backport.js
+++ b/src/e-backport.js
@@ -22,7 +22,7 @@ program
     }
 
     const octokit = new Octokit({
-      auth: process.env.ELECTRON_BUILD_TOOLS_GH_AUTH || (await getGitHubAuthToken(['repo'])),
+      auth: await getGitHubAuthToken(['repo']),
     });
     const { data: user } = await octokit.users.getAuthenticated();
     const { data: pr } = await octokit.pulls.get({

--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -115,7 +115,7 @@ program
       targetBranch = tmp;
     }
     const octokit = new Octokit({
-      auth: process.env.ELECTRON_BUILD_TOOLS_GH_AUTH || (await getGitHubAuthToken(['repo'])),
+      auth: await getGitHubAuthToken(['repo']),
     });
     try {
       const {

--- a/src/e-gh-auth.js
+++ b/src/e-gh-auth.js
@@ -3,7 +3,7 @@
 const d = require('debug')('build-tools:gh-auth');
 const program = require('commander');
 
-const { getGitHubAuthToken } = require('./utils/github-auth');
+const { createGitHubAuthToken } = require('./utils/github-auth');
 const { fatal } = require('./utils/logging');
 
 program
@@ -12,7 +12,7 @@ program
   .allowExcessArguments(false)
   .action(async ({ shell }) => {
     try {
-      const token = await getGitHubAuthToken(['repo']);
+      const token = await createGitHubAuthToken(['repo']);
       if (shell) {
         console.log(`export ELECTRON_BUILD_TOOLS_GH_AUTH="${token}"`);
       } else {

--- a/src/utils/github-auth.js
+++ b/src/utils/github-auth.js
@@ -4,6 +4,10 @@ const { createOAuthDeviceAuth } = require('@octokit/auth-oauth-device');
 const ELECTRON_BUILD_TOOLS_GITHUB_CLIENT_ID = '03581ca0d21228704ab3';
 
 async function getGitHubAuthToken(scopes = []) {
+  if (process.env.ELECTRON_BUILD_TOOLS_GH_AUTH) {
+    return process.env.ELECTRON_BUILD_TOOLS_GH_AUTH;
+  }
+
   try {
     const gh = spawn('gh', ['auth', 'status', '--show-token']);
     const done = new Promise((resolve, reject) => {
@@ -23,6 +27,10 @@ async function getGitHubAuthToken(scopes = []) {
   } catch (e) {
     // fall through to fetching the token through oauth
   }
+  return await createGitHubAuthToken(scopes);
+}
+
+async function createGitHubAuthToken(scopes = []) {
   const auth = createOAuthDeviceAuth({
     clientType: 'oauth-app',
     clientId: ELECTRON_BUILD_TOOLS_GITHUB_CLIENT_ID,
@@ -40,5 +48,6 @@ async function getGitHubAuthToken(scopes = []) {
 }
 
 module.exports = {
+  createGitHubAuthToken,
   getGitHubAuthToken,
 };


### PR DESCRIPTION
Push down the check for `ELECTRON_BUILD_TOOLS_GH_AUTH` into `getGitHubAuthToken` so it won't get missed in future usages of `getGitHubAuthToken`.

Also ensures `e gh-auth` always creates a new token even if the GH cli already has one.