### PR TITLE
chore: update node headers target

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -118,7 +118,24 @@ program
         target = targets['default'];
       }
 
-      runNinja(config, target, options.goma, ninjaArgs);
+      try {
+        runNinja(config, target, options.goma, ninjaArgs);
+      } catch (ex) {
+        if (target === targets['node:headers']) {
+          // Older versions of electron use a different target for node headers so try that if the new one fails.
+          try {
+            const olderTarget = 'third_party/electron_node:headers';
+            console.info(
+              `${color.info} Error building ${target}; trying older ${olderTarget} target`,
+            );
+            runNinja(config, olderTarget, options.goma, ninjaArgs);
+          } catch (ex) {
+            tnrow(ex);
+          }
+        } else {
+          tnrow(ex);
+        }
+      }
     } catch (e) {
       fatal(e);
     }

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -123,17 +123,13 @@ program
       } catch (ex) {
         if (target === targets['node:headers']) {
           // Older versions of electron use a different target for node headers so try that if the new one fails.
-          try {
-            const olderTarget = 'third_party/electron_node:headers';
-            console.info(
-              `${color.info} Error building ${target}; trying older ${olderTarget} target`,
-            );
-            runNinja(config, olderTarget, options.goma, ninjaArgs);
-          } catch (ex) {
-            tnrow(ex);
-          }
+          const olderTarget = 'third_party/electron_node:headers';
+          console.info(
+            `${color.info} Error building ${target}; trying older ${olderTarget} target`,
+          );
+          runNinja(config, olderTarget, options.goma, ninjaArgs);
         } else {
-          tnrow(ex);
+          throw ex;
         }
       }
     } catch (e) {

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -36,7 +36,7 @@ const buildTargets = () => ({
   chromium: 'chrome',
   'electron:dist': 'electron:electron_dist_zip',
   mksnapshot: 'electron:electron_mksnapshot_zip',
-  'node:headers': 'third_party/electron_node:headers',
+  'node:headers': 'electron_node:headers',
   default: getDefaultTarget(),
 });
 

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -36,7 +36,7 @@ const buildTargets = () => ({
   chromium: 'chrome',
   'electron:dist': 'electron:electron_dist_zip',
   mksnapshot: 'electron:electron_mksnapshot_zip',
-  'node:headers': 'electron_node:headers',
+  'node:headers': 'electron:node_headers',
   default: getDefaultTarget(),
 });
 


### PR DESCRIPTION
- https://github.com/electron/electron/pull/39589 changed the node headers target.  This PR updates build-tools to the new target and also provides a fallback to the old target for older versions of Electron.
- Fixes #511 