### PR TITLE
feat: allow disabling `depot_tools` auto-update on sync

### DIFF
--- a/src/e
+++ b/src/e
@@ -67,7 +67,12 @@ program
   .alias('new')
   .command('sync [gclientArgs...]', 'Get or update source code')
   .command('build [options]', 'Build Electron and other things')
-  .alias('make');
+  .alias('make')
+  .command(
+    'depot-tools [depotToolsArgs...]',
+    'Run a command from the depot-tools directory with the correct configuration',
+  )
+  .alias('d');
 
 program
   .command('start [args...]')

--- a/src/e-depot-tools.js
+++ b/src/e-depot-tools.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+const program = require('commander');
+const os = require('os');
+
+const evmConfig = require('./evm-config');
+const { fatal } = require('./utils/logging');
+const depot = require('./utils/depot-tools');
+const goma = require('./utils/goma');
+
+program
+  .command('depot-tools')
+  .description('Run a command from the depot-tools directory with the correct configuration')
+  .allowUnknownOption()
+  .helpOption('\0')
+  .action(() => {
+    depot.ensure();
+
+    const args = process.argv.slice(2);
+    if (args.length === 0) {
+      fatal(`Must provide a command to 'e depot-tools'`);
+    }
+
+    if (args[0] === 'auto-update') {
+      if (!['enable', 'disable'].includes(args[1])) {
+        fatal(`${args[1]} is not a valid argument - options are 'enable' or 'disable'`);
+      }
+
+      const enable = args[1] === 'enable';
+      depot.setAutoUpdate(enable);
+      return;
+    }
+
+    let cwd;
+    if (['goma_ctl', 'goma_auth'].includes(args[0])) {
+      goma.downloadAndPrepare(evmConfig.current());
+      cwd = goma.dir;
+      args[0] = `${args[0]}.py`;
+      args.unshift('python3');
+    }
+
+    if (args[0] === '--') {
+      args.shift();
+    }
+
+    const { status, error } = depot.spawnSync(evmConfig.current(), args[0], args.slice(1), {
+      cwd,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        AGREE_NOTGOMA_TOS: '1',
+      },
+      shell: os.platform() === 'win32',
+    });
+
+    if (status !== 0) {
+      let errorMsg = `Failed to run command:`;
+      if (status !== null) errorMsg += `\n Exit Code: "${status}"`;
+      if (error) errorMsg += `\n ${error}`;
+      fatal(errorMsg, status);
+    }
+
+    if (
+      ['python', 'python3'].includes(args[0]) &&
+      args.slice(1, 3).join(' ') === 'goma_auth.py logout'
+    ) {
+      goma.clearGomaLoginTime();
+    }
+
+    process.exit(0);
+  })
+  .parse(process.argv);

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -9,6 +9,8 @@ const { color } = require('./logging');
 const defaultDepotPath = path.resolve(__dirname, '..', '..', 'third_party', 'depot_tools');
 const DEPOT_TOOLS_DIR = process.env.DEPOT_TOOLS_DIR || defaultDepotPath;
 
+const markerFilePath = path.join(DEPOT_TOOLS_DIR, '.disable_auto_update');
+
 function updateDepotTools() {
   const depot_dir = DEPOT_TOOLS_DIR;
   console.log(`Updating ${color.path(depot_dir)}`);
@@ -131,10 +133,27 @@ function depotExecFileSync(config, exec, args, opts_in) {
   return childProcess.execFileSync(exec, args, opts);
 }
 
+function setAutoUpdate(enable) {
+  try {
+    if (enable) {
+      if (fs.existsSync(markerFilePath)) {
+        fs.unlinkSync(markerFilePath);
+      }
+      console.info(`${color.info} Automatic depot_tools updates enabled`);
+    } else {
+      fs.closeSync(fs.openSync(markerFilePath, 'w'));
+      console.info(`${color.info} Automatic depot_tools updates disabled`);
+    }
+  } catch (e) {
+    fatal(e);
+  }
+}
+
 module.exports = {
   opts: depotOpts,
   path: DEPOT_TOOLS_DIR,
   ensure: ensureDepotTools,
   execFileSync: depotExecFileSync,
   spawnSync: depotSpawnSync,
+  setAutoUpdate,
 };


### PR DESCRIPTION
Allow disabling automatic depot-tools updating - I hit this on the plane on the way over. We call it ourselves but it's also called in some other cases so I took the marker-file approach that [depot_tools understands](https://chromium.googlesource.com/chromium/tools/depot_tools/+/248aa8ba818b752ef507c73db988b6d32bb90df1/update_depot_tools#31) to cover all bases.