### PR TITLE
chore: log info message when depot_tools auto-update disabled

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -32,6 +32,13 @@ function ensureDepotTools() {
     updateDepotTools();
   }
 
+  if (fs.existsSync(markerFilePath)) {
+    console.info(
+      `${color.info} Automatic depot_tools updates disabled, skipping check for updates`,
+    );
+    return;
+  }
+
   // If it's been awhile, update it.
   const now = new Date();
   const msec_per_day = 86400000;


### PR DESCRIPTION
Refs #522 and #493.

It's easy to forget you disabled auto-updates in the past, an info message is useful to prevent any confusion.