### PR TITLE
fix: send "Auto-updates disabled" messages to stderr, not stdout

### DIFF
--- a/src/e
+++ b/src/e
@@ -17,9 +17,13 @@ refreshPathVariable();
 
 function maybeCheckForUpdates() {
   // skip auto-update check if disabled
+  //
+  // NB: send updater's stdout to stderr so its log messages are visible
+  // but don't pollute stdout. For example, calling `FOO="$(e show exec)"`
+  // should not get a FOO that includes "Checking for build-tools updates".
   const disableAutoUpdatesFile = path.resolve(__dirname, '..', '.disable-auto-updates');
   if (fs.existsSync(disableAutoUpdatesFile)) {
-    console.info(`${color.info} Auto-updates disabled, skipping check for updates`);
+    console.error(`${color.info} Auto-updates disabled, skipping check for updates`);
     return;
   }
   // don't check if we already checked recently

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -33,7 +33,10 @@ function ensureDepotTools() {
   }
 
   if (fs.existsSync(markerFilePath)) {
-    console.info(
+    // NB: send updater's stdout to stderr so its log messages are visible
+    // but don't pollute stdout. For example, calling `FOO="$(e show exec)"`
+    // should not get a FOO that includes "Checking for build-tools updates".
+    console.error(
       `${color.info} Automatic depot_tools updates disabled, skipping check for updates`,
     );
     return;


### PR DESCRIPTION
Outputting to stdout breaks commands like `` cd `e show exec` ``, so use stderr instead.

Fixes: 700187712658e6fbdf521aac1a3ca6e8de8f0f2d ("chore: log info message when auto-update disabled")