### PR TITLE
fix: only auto-update main branch

### DIFF
--- a/src/e-auto-update.js
+++ b/src/e-auto-update.js
@@ -122,8 +122,14 @@ function checkForUpdates() {
       );
     }
 
-    console.log(color.childExec('git', ['pull', '--rebase', '--autostash'], execOpts));
-    git('pull --rebase --autostash');
+    console.log(
+      color.childExec(
+        'git',
+        ['pull', 'origin', desiredBranch, '--rebase', '--autostash'],
+        execOpts,
+      ),
+    );
+    git(`pull origin ${desiredBranch} --rebase --autostash`);
 
     if (headBefore === git(headCmd)) {
       console.log('build-tools is up-to-date');


### PR DESCRIPTION
I noticed build-tools pulling down branches which aren't relevant to most users. I've changed auto-update to only pull down main/master.
```
% e build
Checking for build-tools updates
Running "git pull --rebase --autostash" in /Users/samuelmaddock/.electron_build_tools
From https://github.com/electron/build-tools
   dad2c81..c92af31  debug/ci   -> origin/debug/ci
build-tools is up-to-date
```