### PR TITLE
feat: add support for reclient

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -42,6 +42,14 @@
         "msft"
       ]
     },
+    "reclient": {
+      "description": "Whether to use the Electron RBE infrastructure",
+      "type": "string",
+      "enum": [
+        "remote_exec",
+        "none"
+      ]
+    },
     "root": {
       "description": "Path of the top directory. Home of the .gclient file",
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "path-key": "^3.1.0",
     "progress": "^2.0.3",
     "readline-sync": "^1.4.10",
+    "tar": "^6.2.0",
     "vscode-uri": "^3.0.7",
     "which": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "author": "Electron Authors",
   "license": "MIT",
   "dependencies": {
+    "@marshallofsound/chrome-cookies-secure": "^2.1.1",
     "@octokit/auth-oauth-device": "^3.1.1",
     "@octokit/rest": "^18.5.2",
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^2.4.1",
-    "@marshallofsound/chrome-cookies-secure": "^2.1.1",
     "command-exists": "^1.2.8",
     "commander": "^9.0.0",
     "cross-zip": "^3.0.0",

--- a/src/e-depot-tools.js
+++ b/src/e-depot-tools.js
@@ -41,7 +41,7 @@ program
     }
 
     if (args[0] === 'rbe') {
-      reclient.downloadAndPrepare(evmConfig.current());
+      reclient.downloadAndPrepare(evmConfig.current(), true);
       args[0] = reclient.helperPath;
     }
 

--- a/src/e-depot-tools.js
+++ b/src/e-depot-tools.js
@@ -7,6 +7,7 @@ const evmConfig = require('./evm-config');
 const { fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const reclient = require('./utils/reclient');
 
 program
   .command('depot-tools')
@@ -37,6 +38,11 @@ program
       cwd = goma.dir;
       args[0] = `${args[0]}.py`;
       args.unshift('python3');
+    }
+
+    if (args[0] === 'rbe') {
+      reclient.downloadAndPrepare(evmConfig.current());
+      args[0] = reclient.helperPath;
     }
 
     if (args[0] === '--') {

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -96,6 +96,7 @@ function depotOpts(config, opts = {}) {
     ...opts.env,
     // Circular reference so we have to delay load
     ...require('./goma').env(config),
+    ...require('./reclient').env(config),
   };
 
   // put depot tools at the front of the path

--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -14,7 +14,7 @@ const reclientHelperPath = path.resolve(
 );
 const rbeServiceAddress = 'rbe.notgoma.com:443';
 
-const CREDENTIAL_HELPER_TAG = 'v0.1.0';
+const CREDENTIAL_HELPER_TAG = 'v0.2.0';
 
 function downloadAndPrepareReclient(config, force = false) {
   if (config.reclient === 'none' && !force) return;

--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -14,7 +14,7 @@ const reclientHelperPath = path.resolve(
 );
 const rbeServiceAddress = 'rbe.notgoma.com:443';
 
-const CREDENTIAL_HELPER_TAG = 'v0.2.0';
+const CREDENTIAL_HELPER_TAG = 'v0.1.0';
 
 function downloadAndPrepareReclient(config, force = false) {
   if (config.reclient === 'none' && !force) return;

--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -1,0 +1,117 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const { color, fatal } = require('./logging');
+
+const reclientDir = path.resolve(__dirname, '..', '..', 'third_party', 'reclient');
+const reclientTagFile = path.resolve(reclientDir, '.tag');
+const reclientHelperPath = path.resolve(
+  reclientDir,
+  `electron-rbe-credential-helper${process.platform === 'win32' ? '.exe' : ''}`,
+);
+const rbeServiceAddress = 'rbe.notgoma.com:443';
+
+const CREDENTIAL_HELPER_TAG = 'v0.1.0';
+
+function downloadAndPrepareReclient(config) {
+  if (config.reclient === 'none') return;
+
+  // Reclient itself comes down with a "gclient sync"
+  // run.  We just need to ensure we have the cred helper
+  let targetPlatform = null;
+  switch (process.platform) {
+    case 'win32': {
+      targetPlatform = `windows-${process.arch === 'arm64' ? 'arm64' : 'amd64'}`;
+      break;
+    }
+    case 'darwin': {
+      targetPlatform = `darwin-${process.arch === 'arm64' ? 'arm64' : 'amd64'}`;
+      break;
+    }
+    case 'linux': {
+      targetPlatform = `linux-${process.arch === 'arm64' ? 'arm64' : 'amd64'}`;
+      break;
+    }
+  }
+
+  // Not supported
+  if (!targetPlatform) return;
+
+  if (!fs.existsSync(path.dirname(reclientDir))) {
+    fs.mkdirSync(path.dirname(reclientDir));
+  }
+
+  if (
+    fs.existsSync(reclientTagFile) &&
+    fs.readFileSync(reclientTagFile, 'utf8') === CREDENTIAL_HELPER_TAG
+  )
+    return;
+
+  const tmpDownload = path.resolve(reclientDir, '..', 'reclient.tar.gz');
+  // Clean Up
+  rimraf.sync(reclientDir);
+  rimraf.sync(tmpDownload);
+
+  const downloadURL = `https://dev-cdn.electronjs.org/reclient/credential-helper/${CREDENTIAL_HELPER_TAG}/electron-rbe-credential-helper-${targetPlatform}.tar.gz`;
+  console.log(`Downloading ${color.cmd(downloadURL)} into ${color.path(tmpDownload)}`);
+  const { status } = childProcess.spawnSync(
+    process.execPath,
+    [path.resolve(__dirname, '..', 'download.js'), downloadURL, tmpDownload],
+    {
+      stdio: 'inherit',
+    },
+  );
+  if (status !== 0) {
+    rimraf.sync(tmpDownload);
+    fatal(`Failure while downloading reclient`);
+  }
+
+  const targetDir = path.resolve(tmpDownload, '..');
+
+  fs.mkdirSync(reclientDir);
+  const result = childProcess.spawnSync('tar', ['zxvf', 'reclient.tar.gz', '-C', reclientDir], {
+    cwd: targetDir,
+  });
+  if (result.status !== 0) {
+    fatal('Failed to extract reclient');
+  }
+  rimraf.sync(tmpDownload);
+  fs.writeFileSync(reclientTagFile, CREDENTIAL_HELPER_TAG);
+  return;
+}
+
+function reclientEnv(config) {
+  if (config && config.reclient === 'none') {
+    return {};
+  }
+
+  return {
+    RBE_service: rbeServiceAddress,
+    RBE_experimental_credentials_helper: reclientHelperPath,
+  };
+}
+
+function ensureHelperAuth(config) {
+  const result = childProcess.spawnSync(reclientHelperPath, ['status'], {
+    stdio: 'pipe',
+  });
+  if (result.status !== 0) {
+    console.error(result.stdout.toString());
+    console.error(
+      `${color.err} You do not have valid auth for Reclient, please run ${color.cmd(
+        'e d rbe login',
+      )}`,
+    );
+    process.exit(result.status || 1);
+  }
+}
+
+module.exports = {
+  env: reclientEnv,
+  downloadAndPrepare: downloadAndPrepareReclient,
+  helperPath: reclientHelperPath,
+  serviceAddress: rbeServiceAddress,
+  auth: ensureHelperAuth,
+};

--- a/tests/evm-config-spec.js
+++ b/tests/evm-config-spec.js
@@ -14,6 +14,7 @@ const validConfig = {
     },
   },
   goma: 'none',
+  reclient: 'none',
   gen: {
     args: [],
     out: 'Testing',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5049,6 +5049,11 @@ minipass@^4.2.4:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
   integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
 
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
 "minipass@^5.0.0 || ^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-6.0.2.tgz#542844b6c4ce95b202c0995b0a471f1229de4c81"
@@ -6639,6 +6644,18 @@ tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
     minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
+  integrity sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"


### PR DESCRIPTION
This isn't fully ready for public consumption but putting it up now for others to see.  Some missing pieces:
* ~~A more developer friendly way of getting auth onto the machine~~ `e d rbe login`
* ~~Either a more generic hack for https://github.com/bazelbuild/reclient/issues/27 or a real fix upstream~~ Moved TLS termination out of nginx and instead the RBE frontend
* No idea if this even remotely works on windows
* Needs some changes to `e/e` as well https://github.com/electron/electron/pull/40850