### PR TITLE
feat: use reclient on init instead of goma

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -26,6 +26,7 @@
       "minLength": 1
     },
     "goma": {
+      "$comment": "Deprecated, use reclient instead",
       "description": "Goma mode to use",
       "type": "string",
       "enum": [

--- a/example-configs/evm.base.yml
+++ b/example-configs/evm.base.yml
@@ -1,4 +1,5 @@
 root: /path/to/your/developer/folder
+reclient: remote_exec
 remotes:
   electron:
     # SSH or HTTPS url
@@ -7,8 +8,8 @@ remotes:
     origin: git@github.com:electron/electron.git
 gen:
   args:
-    # path to goma for faster builds (https://notgoma.com)
-    - import("/Users/user_name/.electron_build_tools/third_party/goma.gn")
+    # Enable reclient
+    - use_remoteexec = true
   out: Testing
 env:
   GIT_CACHE_PATH: /Users/user_name/.git_cache

--- a/example-configs/evm.chromium.yml
+++ b/example-configs/evm.chromium.yml
@@ -1,9 +1,9 @@
 root: /path/to/chromium/
+reclient: remote_exec
 defaultTarget: chrome
 gen:
   args:
-    # path to goma for faster builds (https://notgoma.com)
-    - import("/Users/user_name/.electron_build_tools/third_party/goma.gn")
+    - use_remoteexec = true
     - is_debug = false
   out: Default
 env:

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -187,7 +187,7 @@ program
       }
 
       // maybe authenticate with RBE
-      if (config.reclient === 'remote_exec') {
+      if (process.env.NODE_ENV !== 'test' && config.reclient === 'remote_exec') {
         childProcess.execFileSync(process.execPath, [e, 'd', 'rbe', 'login'], opts);
       }
 

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -57,7 +57,7 @@ describe('e-init', () => {
 
       const config = require(configPath);
       expect(config).toHaveProperty('$schema');
-      expect(config.goma).toStrictEqual('cache-only');
+      expect(config.reclient).toStrictEqual('remote_exec');
 
       expect(config.remotes).toHaveProperty('electron');
       expect(config.remotes).not.toHaveProperty('node');

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -231,6 +231,7 @@ function createSandbox() {
   const execOptions = {
     encoding: 'utf8',
     env: {
+      NODE_ENV: process.env.NODE_ENV,
       // have `e` use our test sandbox's build-tools config dir
       EVM_CONFIG: evm_config_dir,
 


### PR DESCRIPTION
As in title, init should use reclient now