### PR TITLE
chore: don't install dev dependencies when updating

### DIFF
--- a/src/e-auto-update.js
+++ b/src/e-auto-update.js
@@ -128,8 +128,8 @@ function checkForUpdates() {
     if (headBefore === git(headCmd)) {
       console.log('build-tools is up-to-date');
     } else {
-      console.log(color.childExec('npx', ['yarn'], execOpts));
-      cp.execSync('npx yarn', execOpts);
+      console.log(color.childExec('npx', ['yarn', '--prod'], execOpts));
+      cp.execSync('npx yarn --prod', execOpts);
       console.log('build-tools updated to latest version!');
     }
   } catch (e) {


### PR DESCRIPTION
Users don't need dev dependencies. By not installing them the size of `node_modules` in `.electron_build_tools` goes from 207 MB to 57 MB on my machine.