### PR TITLE
feat: rename --no-goma option to --no-remote

### DIFF
--- a/src/e-test.js
+++ b/src/e-test.js
@@ -39,7 +39,10 @@ program
   .option('--electronVersion <version>', 'Electron release to run tests against')
   .option('--node', 'Run node spec runner', false)
   .option('--nan', 'Run nan spec runner', false)
-  .option('--no-goma', 'Build test runner components (e.g. node:headers) without goma')
+  .option(
+    '--no-remote',
+    'Build test runner components (e.g. node:headers) without remote execution',
+  )
   .addOption(
     new program.Option(
       '--runners <runner>',
@@ -68,7 +71,7 @@ program
         script = './script/nan-spec-runner.js';
       }
       if (!options.electronVersion) {
-        ensureNodeHeaders(config, options.goma);
+        ensureNodeHeaders(config, options.remote);
       }
       runSpecRunner(config, script, specRunnerArgs);
     } catch (e) {

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -5,7 +5,7 @@ const path = require('path');
 const evmConfig = require('../evm-config');
 const { ensureDir } = require('./paths');
 
-function ensureNodeHeaders(config, useGoma) {
+function ensureNodeHeaders(config, useRemote) {
   const src_dir = path.resolve(config.root, 'src');
   const out_dir = evmConfig.outDir(config);
   const node_headers_dir = path.resolve(out_dir, 'gen', 'node_headers');
@@ -24,7 +24,7 @@ function ensureNodeHeaders(config, useGoma) {
   if (needs_build) {
     const exec = process.execPath;
     const args = [path.resolve(__dirname, '..', 'e'), 'build', 'node:headers'];
-    if (!useGoma) args.push('--no-goma');
+    if (!useRemote) args.push('--no-remote');
 
     const opts = { stdio: 'inherit', encoding: 'utf8' };
     childProcess.execFileSync(exec, args, opts);


### PR DESCRIPTION
Rename `--no-goma` to `--no-remote` so that one option works for either Goma or Reclient, and we'll just rip out the Goma code in the future once Goma is no longer supported.