### PR TITLE
test: set user home environment variables in sandbox

### DIFF
--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -240,7 +240,7 @@ function createSandbox() {
 
   // vpython pulls user home directory from environment variables
   if (os.platform() === 'win32') {
-    execOptions.env['%LocalAppData%'] = process.env['%LocalAppData%'];
+    execOptions.env.LocalAppData = process.env.LocalAppData;
   } else {
     execOptions.env.HOME = process.env.HOME;
   }

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -233,7 +233,8 @@ function createSandbox() {
     env: {
       // have `e` use our test sandbox's build-tools config dir
       EVM_CONFIG: evm_config_dir,
-
+      // vpython requires $HOME be set
+      HOME: process.env.HOME,
       [pathKey]: process.env[pathKey],
     },
   };

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -233,11 +233,17 @@ function createSandbox() {
     env: {
       // have `e` use our test sandbox's build-tools config dir
       EVM_CONFIG: evm_config_dir,
-      // vpython requires $HOME be set
-      HOME: process.env.HOME,
+
       [pathKey]: process.env[pathKey],
     },
   };
+
+  // vpython pulls user home directory from environment variables
+  if (os.platform() === 'win32') {
+    execOptions.env['%LocalAppData%'] = process.env['%LocalAppData%'];
+  } else {
+    execOptions.env.HOME = process.env.HOME;
+  }
 
   return {
     cleanup: () => rimraf.sync(tmpdir),


### PR DESCRIPTION
`vpython` has updated to being written in Go upstream, and now throws an error during tests if the user's home directory can't be determined via environment variables.

Refs https://github.com/golang/go/blob/b2dbfbfc2315557815e1d5de12f28ed57f60958a/src/os/file.go#L445-L494