### PR TITLE
chore: remove sccache config handling

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -199,16 +199,6 @@ function sanitizeConfig(name, config, overwrite = false) {
     changes.push(`removed deprecated ${color.config('remotes.node')} property`);
   }
 
-  if (
-    config.goma !== 'none' &&
-    config.gen &&
-    config.gen.args &&
-    config.gen.args.find(arg => arg.includes('cc_wrapper'))
-  ) {
-    config.gen.args = config.gen.args.filter(arg => !arg.includes('cc_wrapper'));
-    changes.push(`removed ${color.config('cc_wrapper')} definition because goma is enabled`);
-  }
-
   if (!config.reclient) {
     config.reclient = 'none';
     changes.push(`defined ${color.config('reclient')} to default value of none`);


### PR DESCRIPTION
I think we can safely remove handling for this as its been several years since it was last relevant.