### PR TITLE
chore: use Dependabot to update GitHub Actions deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Works well over on `electron/fiddle`. Set to monthly to reduce noise.