### PR TITLE
feat: support custom patches config file location

### DIFF
--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -27,6 +27,7 @@ program
       // build the list of targets
       const targets = {};
       const patchesConfig = options.config;
+      if (!fs.existsSync(patchesConfig)) throw `Config file '${patchesConfig}' not found`;
       const configData = JSON.parse(fs.readFileSync(patchesConfig));
       if (Array.isArray(configData)) {
         for (const target of configData) targets[path.basename(target.patch_dir)] = target;

--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -13,6 +13,7 @@ program
   .description(
     "Refresh all patches if 'all' is specified; otherwise, refresh patches in $root/src/electron/patches/$target",
   )
+  .option('-c, --config <filename>', "Specify a config file", path.resolve(evmConfig.current().root, 'src', 'electron', 'patches', 'config.json'))
   .option('--list-targets', 'Show all supported patch targets', false)
   .action((target, options) => {
     try {
@@ -21,7 +22,7 @@ program
 
       // build the list of targets
       const targets = {};
-      const patchesConfig = path.resolve(config.root, 'src', 'electron', 'patches', 'config.json');
+      const patchesConfig = options.config;
       for (const [key, val] of Object.entries(JSON.parse(fs.readFileSync(patchesConfig)))) {
         targets[path.basename(key)] = val;
       }

--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -13,7 +13,11 @@ program
   .description(
     "Refresh all patches if 'all' is specified; otherwise, refresh patches in $root/src/electron/patches/$target",
   )
-  .option('-c, --config <filename>', "Specify a config file", path.resolve(evmConfig.current().root, 'src', 'electron', 'patches', 'config.json'))
+  .option(
+    '-c, --config <filename>',
+    'Specify a config file',
+    path.resolve(evmConfig.current().root, 'src', 'electron', 'patches', 'config.json'),
+  )
   .option('--list-targets', 'Show all supported patch targets', false)
   .action((target, options) => {
     try {
@@ -23,8 +27,12 @@ program
       // build the list of targets
       const targets = {};
       const patchesConfig = options.config;
-      for (const [key, val] of Object.entries(JSON.parse(fs.readFileSync(patchesConfig)))) {
-        targets[path.basename(key)] = val;
+      const configData = JSON.parse(fs.readFileSync(patchesConfig));
+      if (Array.isArray(configData)) {
+        for (const target of configData) targets[path.basename(target.patch_dir)] = target;
+      } else if (typeof configData == 'object') {
+        for (const [patch_dir, repo] of Object.entries(configData))
+          targets[path.basename(patch_dir)] = { patch_dir, repo };
       }
 
       if (options.listTargets) {
@@ -46,13 +54,16 @@ program
           encoding: 'utf8',
         });
       } else if (targets[target]) {
+        const targetConfig = targets[target];
         const script = path.resolve(srcdir, 'electron', 'script', 'git-export-patches');
-        depot.execFileSync(
-          config,
-          'python3',
-          [script, '-o', path.resolve(srcdir, 'electron', 'patches', target)],
-          { cwd: path.resolve(config.root, targets[target]), stdio: 'inherit', encoding: 'utf8' },
-        );
+        const opts = {
+          cwd: path.resolve(config.root, targetConfig.repo),
+          stdio: 'inherit',
+          encoding: 'utf8',
+        };
+        const args = [script, '--output', path.resolve(config.root, targetConfig.patch_dir)];
+        if (targetConfig.grep) args.push('--grep', targetConfig.grep);
+        depot.execFileSync(config, 'python3', args, opts);
       } else {
         console.log(`${color.err} Unrecognized target ${color.cmd(target)}.`);
         console.log(


### PR DESCRIPTION
Changes to `e patches`:

1. Support passing in a custom patches config file instead of always using `electron/patches/config.json`
2. Add support for a `config.json` formatted as an array of objects with `patch_dir` and `repo` properties and an optional `grep` property.

This goes hand-in-hand with https://github.com/electron/electron/pull/41174 for more information; see that PR for more information.

CC @mlaurencin, @jkleinsc 