### PR TITLE
fix: cherry-pick script

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -64,7 +64,7 @@ async function getGerritPatchDetailsFromURL(gerritUrl, security) {
   const [, commitId] = /^From ([0-9a-f]+)/.exec(patch);
 
   const bugNumber =
-    (/^Bug[:=] ?(.+)$/im.exec(patch) || [])[1] || 6(/^Bug= ?chromium:(.+)$/m.exec(patch) || [])[1];
+    /^Bug[:=] ?(.+)$/im.exec(patch)?.[1] || /^Bug= ?chromium:(.+)$/m.exec(patch)?.[1];
   const cve = security ? await getCveForBugNr(bugNumber.replace('chromium:', '')) : '';
 
   const patchDirName =


### PR DESCRIPTION
A recent change to the cherry-pick script includes a typo which tries to call the number `6` as a function.

I also took the liberty to simplify the code using the [Optional chaining operator `?.`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which has been stable in Node.js since v14 (4 years ago).