### PR TITLE
refactor: remove rimraf usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "jest": "^27.5.1",
     "lint-staged": "^10.0.2",
     "nyc": "^14.1.1",
-    "prettier": "^1.19.1",
-    "rimraf": "^3.0.0"
+    "prettier": "^1.19.1"
   },
   "lint-staged": {
     "*.js": [

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -2,7 +2,6 @@ const childProcess = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
 const { unzipSync } = require('cross-zip');
 const { color, fatal } = require('./logging');
 const depot = require('./depot-tools');
@@ -82,8 +81,8 @@ function downloadAndPrepareGoma(config) {
 
   const tmpDownload = path.resolve(gomaDir, '..', filename);
   // Clean Up
-  rimraf.sync(gomaDir);
-  rimraf.sync(tmpDownload);
+  fs.rmSync(gomaDir, { force: true, recursive: true });
+  fs.rmSync(tmpDownload, { force: true, recursive: true });
 
   const downloadURL = `${gomaBaseURL}/${sha}/${filename}`;
   console.log(`Downloading ${color.cmd(downloadURL)} into ${color.path(tmpDownload)}`);
@@ -95,7 +94,7 @@ function downloadAndPrepareGoma(config) {
     },
   );
   if (status !== 0) {
-    rimraf.sync(tmpDownload);
+    fs.rmSync(tmpDownload, { force: true, recursive: true });
     fatal(`Failure while downloading goma`);
   }
   const hash = crypto
@@ -108,7 +107,7 @@ function downloadAndPrepareGoma(config) {
         sha,
       )}. Halting now`,
     );
-    rimraf.sync(tmpDownload);
+    fs.rmSync(tmpDownload, { force: true, recursive: true });
     process.exit(1);
   }
 
@@ -123,7 +122,7 @@ function downloadAndPrepareGoma(config) {
   } else {
     unzipSync(tmpDownload, targetDir);
   }
-  rimraf.sync(tmpDownload);
+  fs.rmSync(tmpDownload, { force: true, recursive: true });
   fs.writeFileSync(gomaShaFile, sha);
   return sha;
 }

--- a/src/utils/goma.js
+++ b/src/utils/goma.js
@@ -7,6 +7,7 @@ const { color, fatal } = require('./logging');
 const depot = require('./depot-tools');
 const os = require('os');
 const { getIsArm } = require('./arm');
+const { deleteDir } = require('./paths');
 
 const gomaDir = path.resolve(__dirname, '..', '..', 'third_party', 'goma');
 const gomaGnFile = path.resolve(__dirname, '..', '..', 'third_party', 'goma.gn');
@@ -81,8 +82,8 @@ function downloadAndPrepareGoma(config) {
 
   const tmpDownload = path.resolve(gomaDir, '..', filename);
   // Clean Up
-  fs.rmSync(gomaDir, { force: true, recursive: true });
-  fs.rmSync(tmpDownload, { force: true, recursive: true });
+  deleteDir(gomaDir);
+  deleteDir(tmpDownload);
 
   const downloadURL = `${gomaBaseURL}/${sha}/${filename}`;
   console.log(`Downloading ${color.cmd(downloadURL)} into ${color.path(tmpDownload)}`);
@@ -94,7 +95,7 @@ function downloadAndPrepareGoma(config) {
     },
   );
   if (status !== 0) {
-    fs.rmSync(tmpDownload, { force: true, recursive: true });
+    deleteDir(tmpDownload);
     fatal(`Failure while downloading goma`);
   }
   const hash = crypto
@@ -107,7 +108,7 @@ function downloadAndPrepareGoma(config) {
         sha,
       )}. Halting now`,
     );
-    fs.rmSync(tmpDownload, { force: true, recursive: true });
+    deleteDir(tmpDownload);
     process.exit(1);
   }
 
@@ -122,7 +123,7 @@ function downloadAndPrepareGoma(config) {
   } else {
     unzipSync(tmpDownload, targetDir);
   }
-  fs.rmSync(tmpDownload, { force: true, recursive: true });
+  deleteDir(tmpDownload);
   fs.writeFileSync(gomaShaFile, sha);
   return sha;
 }

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -17,7 +17,10 @@ function ensureDir(dir) {
   }
 }
 
+const deleteDir = dir => fs.rmSync(dir, { force: true, recursive: true });
+
 module.exports = {
   resolvePath,
   ensureDir,
+  deleteDir,
 };

--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -4,6 +4,7 @@ const path = require('path');
 const tar = require('tar');
 
 const { color, fatal } = require('./logging');
+const { deleteDir } = require('./paths');
 
 const reclientDir = path.resolve(__dirname, '..', '..', 'third_party', 'reclient');
 const reclientTagFile = path.resolve(reclientDir, '.tag');
@@ -51,8 +52,8 @@ function downloadAndPrepareReclient(config, force = false) {
 
   const tmpDownload = path.resolve(reclientDir, '..', 'reclient.tar.gz');
   // Clean Up
-  fs.rmSync(reclientDir, { force: true, recursive: true });
-  fs.rmSync(tmpDownload, { force: true, recursive: true });
+  deleteDir(reclientDir);
+  deleteDir(tmpDownload);
 
   const downloadURL = `https://dev-cdn.electronjs.org/reclient/credential-helper/${CREDENTIAL_HELPER_TAG}/electron-rbe-credential-helper-${targetPlatform}.tar.gz`;
   console.log(`Downloading ${color.cmd(downloadURL)} into ${color.path(tmpDownload)}`);
@@ -64,7 +65,7 @@ function downloadAndPrepareReclient(config, force = false) {
     },
   );
   if (status !== 0) {
-    fs.rmSync(tmpDownload, { force: true, recursive: true });
+    deleteDir(tmpDownload);
     fatal(`Failure while downloading reclient`);
   }
 
@@ -80,7 +81,7 @@ function downloadAndPrepareReclient(config, force = false) {
     fs.renameSync(reclientHelperPath.replace(/\.exe$/, ''), reclientHelperPath);
   }
 
-  fs.rmSync(tmpDownload, { force: true, recursive: true });
+  deleteDir(tmpDownload);
   fs.writeFileSync(reclientTagFile, CREDENTIAL_HELPER_TAG);
   return;
 }

--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -1,7 +1,6 @@
 const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
 const tar = require('tar');
 
 const { color, fatal } = require('./logging');
@@ -52,8 +51,8 @@ function downloadAndPrepareReclient(config, force = false) {
 
   const tmpDownload = path.resolve(reclientDir, '..', 'reclient.tar.gz');
   // Clean Up
-  rimraf.sync(reclientDir);
-  rimraf.sync(tmpDownload);
+  fs.rmSync(reclientDir, { force: true, recursive: true });
+  fs.rmSync(tmpDownload, { force: true, recursive: true });
 
   const downloadURL = `https://dev-cdn.electronjs.org/reclient/credential-helper/${CREDENTIAL_HELPER_TAG}/electron-rbe-credential-helper-${targetPlatform}.tar.gz`;
   console.log(`Downloading ${color.cmd(downloadURL)} into ${color.path(tmpDownload)}`);
@@ -65,7 +64,7 @@ function downloadAndPrepareReclient(config, force = false) {
     },
   );
   if (status !== 0) {
-    rimraf.sync(tmpDownload);
+    fs.rmSync(tmpDownload, { force: true, recursive: true });
     fatal(`Failure while downloading reclient`);
   }
 
@@ -81,7 +80,7 @@ function downloadAndPrepareReclient(config, force = false) {
     fs.renameSync(reclientHelperPath.replace(/\.exe$/, ''), reclientHelperPath);
   }
 
-  rimraf.sync(tmpDownload);
+  fs.rmSync(tmpDownload, { force: true, recursive: true });
   fs.writeFileSync(reclientTagFile, CREDENTIAL_HELPER_TAG);
   return;
 }

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -1,7 +1,6 @@
 const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
 const semver = require('semver');
 const { ensureDir } = require('./paths');
 const evmConfig = require('../evm-config');
@@ -98,7 +97,7 @@ function removeUnusedXcodes() {
 
   const { preserveXcode } = evmConfig.current();
   for (const { name } of recent.slice(preserveXcode)) {
-    rimraf.sync(name);
+    fs.rmSync(name, { force: true, recursive: true });
   }
 }
 
@@ -181,7 +180,7 @@ function fixBadVersioned103() {
   const good = path.resolve(XcodeDir, `Xcode-10.3.0.app`);
   if (fs.existsSync(bad)) {
     if (fs.existsSync(good)) {
-      rimraf.sync(bad);
+      fs.rmSync(bad, { force: true, recursive: true });
     } else {
       fs.renameSync(bad, good);
     }
@@ -211,7 +210,7 @@ function ensureXcode() {
               existingHash,
             )} which did not match ${color.cmd(expectedXcodeHash)} so redownloading Xcode`,
           );
-          rimraf.sync(XcodeZip);
+          fs.rmSync(XcodeZip, { force: true, recursive: true });
         }
       }
 
@@ -227,13 +226,13 @@ function ensureXcode() {
         );
 
         if (status !== 0) {
-          rimraf.sync(XcodeZip);
+          fs.rmSync(XcodeZip, { force: true, recursive: true });
           fatal(`Failure while downloading Xcode zip`);
         }
 
         const newHash = hashFile(XcodeZip);
         if (newHash !== expectedXcodeHash) {
-          rimraf.sync(XcodeZip);
+          fs.rmSync(XcodeZip, { force: true, recursive: true });
           fatal(
             `Downloaded Xcode zip had hash "${newHash}" which does not match expected hash "${expectedXcodeHash}"`,
           );
@@ -242,14 +241,14 @@ function ensureXcode() {
 
       console.log(`Extracting ${color.cmd(XcodeZip)} into ${color.path(eventualVersionedPath)}`);
       const unzipPath = path.resolve(XcodeDir, 'tmp_unzip');
-      rimraf.sync(unzipPath);
+      fs.rmSync(unzipPath, { force: true, recursive: true });
       cp.spawnSync('unzip', ['-q', '-o', XcodeZip, '-d', unzipPath], {
         stdio: 'inherit',
       });
 
       fs.renameSync(path.resolve(unzipPath, 'Xcode.app'), eventualVersionedPath);
-      rimraf.sync(XcodeZip);
-      rimraf.sync(unzipPath);
+      fs.rmSync(XcodeZip, { force: true, recursive: true });
+      fs.rmSync(unzipPath, { force: true, recursive: true });
     }
 
     if (fs.existsSync(XcodePath)) {
@@ -260,7 +259,7 @@ function ensureXcode() {
         if (!fs.existsSync(versionedXcode)) {
           fs.renameSync(XcodePath, versionedXcode);
         } else {
-          rimraf.sync(XcodePath);
+          fs.rmSync(XcodePath, { force: true, recursive: true });
         }
       }
     }
@@ -269,7 +268,7 @@ function ensureXcode() {
     fs.symlinkSync(eventualVersionedPath, XcodePath);
   }
 
-  rimraf.sync(XcodeZip);
+  fs.rmSync(XcodeZip, { force: true, recursive: true });
 
   removeUnusedXcodes();
 

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -6,6 +6,7 @@ const { ensureDir } = require('./paths');
 const evmConfig = require('../evm-config');
 
 const { color, fatal } = require('./logging');
+const { deleteDir } = require('./paths');
 
 const XcodeDir = path.resolve(__dirname, '..', '..', 'third_party', 'Xcode');
 const XcodePath = path.resolve(XcodeDir, 'Xcode.app');
@@ -97,7 +98,7 @@ function removeUnusedXcodes() {
 
   const { preserveXcode } = evmConfig.current();
   for (const { name } of recent.slice(preserveXcode)) {
-    fs.rmSync(name, { force: true, recursive: true });
+    deleteDir(name);
   }
 }
 
@@ -180,7 +181,7 @@ function fixBadVersioned103() {
   const good = path.resolve(XcodeDir, `Xcode-10.3.0.app`);
   if (fs.existsSync(bad)) {
     if (fs.existsSync(good)) {
-      fs.rmSync(bad, { force: true, recursive: true });
+      deleteDir(bad);
     } else {
       fs.renameSync(bad, good);
     }
@@ -210,7 +211,7 @@ function ensureXcode() {
               existingHash,
             )} which did not match ${color.cmd(expectedXcodeHash)} so redownloading Xcode`,
           );
-          fs.rmSync(XcodeZip, { force: true, recursive: true });
+          deleteDir(XcodeZip);
         }
       }
 
@@ -226,13 +227,13 @@ function ensureXcode() {
         );
 
         if (status !== 0) {
-          fs.rmSync(XcodeZip, { force: true, recursive: true });
+          deleteDir(XcodeZip);
           fatal(`Failure while downloading Xcode zip`);
         }
 
         const newHash = hashFile(XcodeZip);
         if (newHash !== expectedXcodeHash) {
-          fs.rmSync(XcodeZip, { force: true, recursive: true });
+          deleteDir(XcodeZip);
           fatal(
             `Downloaded Xcode zip had hash "${newHash}" which does not match expected hash "${expectedXcodeHash}"`,
           );
@@ -241,14 +242,14 @@ function ensureXcode() {
 
       console.log(`Extracting ${color.cmd(XcodeZip)} into ${color.path(eventualVersionedPath)}`);
       const unzipPath = path.resolve(XcodeDir, 'tmp_unzip');
-      fs.rmSync(unzipPath, { force: true, recursive: true });
+      deleteDir(unzipPath);
       cp.spawnSync('unzip', ['-q', '-o', XcodeZip, '-d', unzipPath], {
         stdio: 'inherit',
       });
 
       fs.renameSync(path.resolve(unzipPath, 'Xcode.app'), eventualVersionedPath);
-      fs.rmSync(XcodeZip, { force: true, recursive: true });
-      fs.rmSync(unzipPath, { force: true, recursive: true });
+      deleteDir(XcodeZip);
+      deleteDir(unzipPath);
     }
 
     if (fs.existsSync(XcodePath)) {
@@ -259,7 +260,7 @@ function ensureXcode() {
         if (!fs.existsSync(versionedXcode)) {
           fs.renameSync(XcodePath, versionedXcode);
         } else {
-          fs.rmSync(XcodePath, { force: true, recursive: true });
+          deleteDir(XcodePath);
         }
       }
     }
@@ -268,7 +269,7 @@ function ensureXcode() {
     fs.symlinkSync(eventualVersionedPath, XcodePath);
   }
 
-  fs.rmSync(XcodeZip, { force: true, recursive: true });
+  deleteDir(XcodeZip);
 
   removeUnusedXcodes();
 

--- a/tests/e-update-goma-spec.js
+++ b/tests/e-update-goma-spec.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 const goma = require('../src/utils/goma');
+const { deleteDir } = require('../src/utils/paths');
 
 afterAll(() => {
-  fs.rmSync(goma.dir, { recursive: true, force: true });
+  deleteDir(goma.dir);
 });
 
 describe('e update-goma', () => {

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -2,6 +2,7 @@ const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { deleteDir } = require('../src/utils/paths');
 
 // Get the PATH environment variable key cross-platform
 // It's usually PATH, but on Windows it can be any casing like Path...
@@ -244,7 +245,7 @@ function createSandbox() {
   }
 
   return {
-    cleanup: () => fs.rmSync(tmpdir, { force: true, recursive: true }),
+    cleanup: () => deleteDir(tmpdir),
     eInitRunner: () => {
       return eInitRunner(execOptions);
     },

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -3,9 +3,6 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-// for `rm -rf`'ing the sandbox tmpdir
-const rimraf = require('rimraf');
-
 // Get the PATH environment variable key cross-platform
 // It's usually PATH, but on Windows it can be any casing like Path...
 // https://github.com/sindresorhus/path-key
@@ -247,7 +244,7 @@ function createSandbox() {
   }
 
   return {
-    cleanup: () => rimraf.sync(tmpdir),
+    cleanup: () => fs.rmSync(tmpdir, { force: true, recursive: true }),
     eInitRunner: () => {
       return eInitRunner(execOptions);
     },


### PR DESCRIPTION
`rimraf` was pulled into Node.js core in v14, and we can use native `fs` methods to achieve the same end, e.g. `rimraf.sync(path)` -> `fs.rmSync(path, { force: true, recursive: true })`