### PR TITLE
chore: add support for alternative RBE cluster and helper

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -57,6 +57,14 @@
         "none"
       ]
     },
+    "reclientHelperPath": {
+      "description": "Path to alternative reclient credential helper",
+      "type": "string"
+    },
+    "reclientServiceAddress": {
+      "description": "Alternative RBE cluster address",
+      "type": "string"
+    },
     "root": {
       "description": "Path of the top directory. Home of the .gclient file",
       "type": "string",

--- a/src/e-depot-tools.js
+++ b/src/e-depot-tools.js
@@ -42,7 +42,7 @@ program
 
     if (args[0] === 'rbe') {
       reclient.downloadAndPrepare(evmConfig.current(), true);
-      args[0] = reclient.helperPath;
+      args[0] = reclient.helperPath(evmConfig.current());
     }
 
     if (args[0] === '--') {

--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -18,6 +18,14 @@ const CREDENTIAL_HELPER_TAG = 'v0.2.2';
 
 function downloadAndPrepareReclient(config, force = false) {
   if (config.reclient === 'none' && !force) return;
+  // If a custom reclient credentials helper is specified, expect
+  // that it exists in the specified location
+  if (config.reclientHelperPath) {
+    console.log(
+      `Using custom reclient credentials helper at  ${color.path(config.reclientHelperPath)}`,
+    );
+    return;
+  }
 
   // Reclient itself comes down with a "gclient sync"
   // run.  We just need to ensure we have the cred helper
@@ -92,8 +100,8 @@ function reclientEnv(config) {
   }
 
   return {
-    RBE_service: rbeServiceAddress,
-    RBE_experimental_credentials_helper: reclientHelperPath,
+    RBE_service: config.reclientServiceAddress || rbeServiceAddress,
+    RBE_experimental_credentials_helper: getHelperPath(config),
     RBE_experimental_credentials_helper_args: 'print',
   };
 }
@@ -113,10 +121,14 @@ function ensureHelperAuth(config) {
   }
 }
 
+function getHelperPath(config) {
+  return config.reclientHelperPath || reclientHelperPath;
+}
+
 module.exports = {
   env: reclientEnv,
   downloadAndPrepare: downloadAndPrepareReclient,
-  helperPath: reclientHelperPath,
+  helperPath: getHelperPath,
   serviceAddress: rbeServiceAddress,
   auth: ensureHelperAuth,
 };


### PR DESCRIPTION
This PR adds two configs to allow use of an alternative RBE cluster with build tools:

* **reclientHelperPath** - Path to alternative reclient credential helper. When using this option, build-tools will assume that the helper is already properly installed at the specified path.
* **reclientServiceAddress** - Alternative RBE cluster address 