### PR TITLE
refactor: try authenticating with codespaces on initial build

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -167,6 +167,18 @@ function validateConfig(config) {
   }
 }
 
+function overwriteValue({ name, key, value }) {
+  const configName = name ?? currentName();
+  const config = loadConfigFileRaw(name);
+
+  if (!config.hasOwnProperty(key)) {
+    fatal(`Config ${color.config(configName)} does not have property ${color.config(key)}`);
+  }
+
+  config[key] = value;
+  save(configName, config);
+}
+
 function sanitizeConfig(name, config, overwrite = false) {
   const changes = [];
 
@@ -318,6 +330,7 @@ module.exports = {
   fetchByName: name => sanitizeConfigWithName(name),
   names,
   outDir,
+  overwriteValue,
   pathOf,
   remove,
   sanitizeConfig,

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -171,7 +171,7 @@ function overwriteValue({ name, key, value }) {
   const configName = name ?? currentName();
   const config = loadConfigFileRaw(name);
 
-  if (!config.hasOwnProperty(key)) {
+  if (!config.has(key)) {
     fatal(`Config ${color.config(configName)} does not have property ${color.config(key)}`);
   }
 


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/41428#issuecomment-1962188175.

Reworks reclient auth a bit to be more similar to goma in that if a user tries to build with reclient enabled, they will be prompted to log in. This also allows us to add some extra logic for codespaces so that we can auth during build instead of in. the oncreate lifecycle command.