### PR TITLE
fix: load xcode before `e init` 

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -181,13 +181,7 @@ program
         }
       }
 
-      // ensure xcode is loaded
-      if (process.platform === 'darwin') {
-        loadXcode(true);
-      }
-
       // save the new config
-      ensureRoot(config, !!options.force);
       evmConfig.save(name, config);
       console.log(`New build config ${color.config(name)} created in ${color.path(filename)}`);
 
@@ -195,6 +189,13 @@ program
       const e = path.resolve(__dirname, 'e');
       const opts = { stdio: 'inherit' };
       childProcess.execFileSync(process.execPath, [e, 'use', name], opts);
+
+      // ensure xcode is loaded
+      if (process.platform === 'darwin') {
+        loadXcode(true);
+      }
+
+      ensureRoot(config, !!options.force);
 
       // (maybe) run sync to ensure external binaries are downloaded
       if (options.bootstrap) {

--- a/src/e-init.js
+++ b/src/e-init.js
@@ -13,6 +13,7 @@ const { resolvePath, ensureDir } = require('./utils/paths');
 const reclient = require('./utils/reclient');
 const depot = require('./utils/depot-tools');
 const { checkGlobalGitConfig } = require('./utils/git');
+const { loadXcode } = require('./utils/load-xcode');
 
 // https://gn.googlesource.com/gn/+/main/docs/reference.md?pli=1#var_target_cpu
 const archOption = new Option(
@@ -178,6 +179,11 @@ program
             )} already exists and points at a different root folder! (${color.path(filename)})`,
           );
         }
+      }
+
+      // ensure xcode is loaded
+      if (process.platform === 'darwin') {
+        loadXcode(true);
       }
 
       // save the new config

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -8,6 +8,7 @@ const evmConfig = require('./evm-config');
 const { fatal } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const depot = require('./utils/depot-tools');
+const { loadXcode } = require('./utils/load-xcode');
 
 function setRemotes(cwd, repo) {
   for (const remote in repo) {
@@ -38,6 +39,11 @@ function runGClientSync(syncArgs, syncOpts) {
 
   if (config.env.GIT_CACHE_PATH) {
     ensureDir(config.env.GIT_CACHE_PATH);
+  }
+
+  // ensure xcode is loaded
+  if (process.platform === 'darwin') {
+    loadXcode(true);
   }
 
   depot.ensure();

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -8,7 +8,6 @@ const evmConfig = require('./evm-config');
 const { fatal } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const depot = require('./utils/depot-tools');
-const { loadXcode } = require('./utils/load-xcode');
 
 function setRemotes(cwd, repo) {
   for (const remote in repo) {
@@ -39,11 +38,6 @@ function runGClientSync(syncArgs, syncOpts) {
 
   if (config.env.GIT_CACHE_PATH) {
     ensureDir(config.env.GIT_CACHE_PATH);
-  }
-
-  // ensure xcode is loaded
-  if (process.platform === 'darwin') {
-    loadXcode(true);
   }
 
   depot.ensure();

--- a/src/utils/load-xcode.js
+++ b/src/utils/load-xcode.js
@@ -17,6 +17,12 @@ function loadXcode(options = {}) {
     fatal('Should only configure Xcode on darwin platform');
   }
 
+  // For testing purposes
+  if (process.env.__JEST__) {
+    console.log('TEST: loadXcode called');
+    return;
+  }
+
   if (Xcode.ensureXcode(target) === false) {
     return;
   }

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -192,4 +192,22 @@ describe('e-init', () => {
     expect(result.exitCode).toStrictEqual(0);
     expect(result.stdout).toStrictEqual('Debug');
   });
+
+  it('loadXcode is called on macOS', () => {
+    const root = path.resolve(sandbox.tmpdir, 'main');
+    const result = sandbox
+      .eInitRunner()
+      .root(root)
+      .import('debug')
+      .name('name')
+      .run();
+
+    expect(result.exitCode).toStrictEqual(0);
+    const output = expect.stringContaining('TEST: loadXcode called');
+    if (process.platform === 'darwin') {
+      expect(result.stdout).toEqual(output);
+    } else {
+      expect(result.stdout).not.toEqual(output);
+    }
+  });
 });

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -149,7 +149,6 @@ describe('e-init', () => {
       .name('name')
       .force()
       .run();
-    expect(result.stderr).toEqual('');
     expect(result.exitCode).toStrictEqual(0);
   });
 

--- a/tests/e-init-spec.js
+++ b/tests/e-init-spec.js
@@ -149,6 +149,7 @@ describe('e-init', () => {
       .name('name')
       .force()
       .run();
+    expect(result.stderr).toEqual('');
     expect(result.exitCode).toStrictEqual(0);
   });
 

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -232,7 +232,8 @@ function createSandbox() {
       NODE_ENV: process.env.NODE_ENV,
       // have `e` use our test sandbox's build-tools config dir
       EVM_CONFIG: evm_config_dir,
-
+      // we want to detect jest
+      __JEST__: 1,
       [pathKey]: process.env[pathKey],
     },
   };


### PR DESCRIPTION
This PR:
- [x] fixes #513 and loads xcode before `e init`  runs git commands inside build tools
