### PR TITLE
chore: update windows toolchain

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -70,7 +70,7 @@ function platformOpts() {
         GYP_MSVS_HASH_e41785f09f: 'e146e01913',
         GYP_MSVS_HASH_1023ce2e82: '3a908a0f94',
         GYP_MSVS_HASH_27370823e7: '28622d16b1',
-        GYP_MSVS_HASH_7393122652: 'ed064bd513'
+        GYP_MSVS_HASH_7393122652: 'ed064bd513',
       };
   }
 

--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -70,6 +70,7 @@ function platformOpts() {
         GYP_MSVS_HASH_e41785f09f: 'e146e01913',
         GYP_MSVS_HASH_1023ce2e82: '3a908a0f94',
         GYP_MSVS_HASH_27370823e7: '28622d16b1',
+        GYP_MSVS_HASH_7393122652: 'ed064bd513'
       };
   }
 


### PR DESCRIPTION
Adding support for [New toolchain for Windows 11 10.0.22621.2428 SDK](https://chromium-review.googlesource.com/c/chromium/src/+/5350823) to build-tools