### PR TITLE
docs: add backport description

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,12 @@ $ e shell
 
 `e backport <PR>` assists with manual backport processes on the specified pull request.
 
+To see all potential options for this command, run:
+
+```sh
+$ e backport --help
+```
+
 Example:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ and building the code. `e` wraps these tools:
 | e sync  | Get / update / synchronize source code branches                |
 | e build | Build it!                                                      |
 
-### e init
+### `e init`
 
 `e init` initializes a new local development environment for Electron.
 
@@ -398,6 +398,29 @@ Developers may for example find themselves wishing to access `gn` and `ninja` di
 $ e shell
 # Launching build-tools shell with "/bin/zsh"
 # Running "/bin/zsh"
+```
+
+### `e backport <PR>`
+
+`e backport <PR>` assists with manual backport processes the specified pull request.
+
+Example:
+
+```sh
+# select the PR to backport
+e backport 1234
+
+# select branch you want to backport PR to
+30-x-y
+
+# resolve any merge conflicts
+git cherry-pick --continue
+
+# push changes
+git push
+
+# create pull request
+e pr --backport 1234
 ```
 
 ## Common Usage

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ $ e shell
 
 ### `e backport <PR>`
 
-`e backport <PR>` assists with manual backport processes the specified pull request.
+`e backport <PR>` assists with manual backport processes on the specified pull request.
 
 Example:
 


### PR DESCRIPTION
This PR:
- [x] Adds a description and example to `e backport <PR>`