### PR TITLE
build(deps): add semver to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "progress": "^2.0.3",
     "readline-sync": "^1.4.10",
     "tar": "^6.2.1",
+    "semver": "^7.6.0",
     "vscode-uri": "^3.0.7",
     "which": "^2.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,6 +6149,13 @@ semver@^7.0.0, semver@^7.3.2, semver@^7.3.5, semver@^7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
Closes https://github.com/electron/build-tools/issues/577.

Standardize on a version of semver.