### PR TITLE
fix: EINVAL when spawning on Windows

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -82,6 +82,7 @@ function depotOpts(config, opts = {}) {
   opts = {
     encoding: 'utf8',
     stdio: 'inherit',
+    shell: process.platform === 'win32',
     ...opts,
   };
 

--- a/src/utils/refresh-path.js
+++ b/src/utils/refresh-path.js
@@ -4,7 +4,7 @@ const path = require('path');
 const refreshPathVariable = () => {
   if (process.platform === 'win32') {
     const file = path.resolve(__dirname, 'get-path.bat');
-    const output = cp.execFileSync(file);
+    const output = cp.execFileSync(file, { shell: true });
     const pathOut = output.toString();
     process.env.PATH = pathOut;
   }

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -27,6 +27,11 @@ function runSync(args, options) {
     exitCode: 0,
   };
 
+  // Necessary when spawning .cmd on Windows.
+  if (process.platform === 'win32') {
+    options = { ...options, shell: true };
+  }
+
   try {
     if (debug) console.log(args);
     const out = childProcess.execFileSync(spawnCmd, args, options);


### PR DESCRIPTION
Refs https://github.com/nodejs/node/issues/52554

After the latest security fix on Node.js on Windows, spawning `.cmd` files is blocked unless `{ shell: true }` is used.
