### PR TITLE
fix: output directly to args.gn

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -9,6 +9,7 @@ const evmConfig = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
 const depot = require('./utils/depot-tools');
 const goma = require('./utils/goma');
+const { ensureDir } = require('./utils/paths');
 const reclient = require('./utils/reclient');
 const { loadXcode } = require('./utils/load-xcode');
 
@@ -18,6 +19,7 @@ function runGNGen(config) {
   const gnPath = path.resolve(depot.path, gnBasename);
   const gnArgs = config.gen.args.join(os.EOL);
   const argsFile = path.resolve(evmConfig.outDir(config), 'args.gn');
+  ensureDir(evmConfig.outDir(config));
   fs.writeFileSync(argsFile, gnArgs, { encoding: 'utf8' });
   const execArgs = ['gen', `out/${config.gen.out}`];
   const execOpts = { cwd: path.resolve(config.root, 'src') };

--- a/src/e-build.js
+++ b/src/e-build.js
@@ -16,8 +16,10 @@ function runGNGen(config) {
   depot.ensure();
   const gnBasename = os.platform() === 'win32' ? 'gn.bat' : 'gn';
   const gnPath = path.resolve(depot.path, gnBasename);
-  const gnArgs = config.gen.args.join(' ');
-  const execArgs = ['gen', `out/${config.gen.out}`, `--args=${gnArgs}`];
+  const gnArgs = config.gen.args.join(os.EOL);
+  const argsFile = path.resolve(evmConfig.outDir(config), 'args.gn');
+  fs.writeFileSync(argsFile, gnArgs, { encoding: 'utf8' });
+  const execArgs = ['gen', `out/${config.gen.out}`];
   const execOpts = { cwd: path.resolve(config.root, 'src') };
   depot.execFileSync(config, gnPath, execArgs, execOpts);
 }
@@ -29,8 +31,7 @@ function ensureGNGen(config) {
   if (!fs.existsSync(argsFile)) return runGNGen(config);
   const contents = fs.readFileSync(argsFile, 'utf8');
   // If the current args do not match the args file, re-run gen
-  if (contents.trim() !== config.gen.args.join(process.platform === 'win32' ? '\r\n' : '\n').trim())
-    return runGNGen(config);
+  if (contents.trim() !== config.gen.args.join(os.EOL).trim()) return runGNGen(config);
 }
 
 function runNinja(config, target, useRemote, ninjaArgs) {


### PR DESCRIPTION
Fixes #582.

With the changes in #581, a shell is now being used to execute `gn.bat` on Windows and as a result the GN arguments are no longer interpreted correctly (due to spaces between arguments). Seemed simplest to dump them directly into `args.gn` rather than escape quotes and potentially miss some corner cases.