### PR TITLE
fix: check for errors in more places

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -94,7 +94,11 @@ function runGClientConfig(config) {
     cwd: root,
     shell: true,
   };
-  depot.spawnSync(config, exec, args, opts);
+  const { status } = depot.spawnSync(config, exec, args, opts);
+
+  if (status !== 0) {
+    fatal('gclient config failed');
+  }
 }
 
 function ensureRoot(config, force) {

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -251,9 +251,12 @@ function ensureXcode(target) {
       console.log(`Extracting ${color.cmd(XcodeZip)} into ${color.path(eventualVersionedPath)}`);
       const unzipPath = path.resolve(XcodeDir, 'tmp_unzip');
       deleteDir(unzipPath);
-      cp.spawnSync('unzip', ['-q', '-o', XcodeZip, '-d', unzipPath], {
+      const { status } = cp.spawnSync('unzip', ['-q', '-o', XcodeZip, '-d', unzipPath], {
         stdio: 'inherit',
       });
+      if (status !== 0) {
+        fatal('Failure while extracting Xcode zip');
+      }
 
       fs.renameSync(path.resolve(unzipPath, 'Xcode.app'), eventualVersionedPath);
       deleteDir(XcodeZip);


### PR DESCRIPTION
Managed to break my Windows checkout in ✨ New and Exciting Ways ✨ while trying to get it out of a bad state.

As a result of debugging how it had gotten so bungled, found there are a handful of cases where the status code from `spawnSync` isn't being checked, so this tightens those down for good measure so it doesn't create more problems if those commands fail.

This also adds a check to confirm that it's setting git remotes in the expected git repo, as one of the exciting ways my checkout broke was the remotes on `src/` were overwritten to point to `electron/electron.git`. Some combination of `e sync` failing leaving `src/` unpatched, then a following `e sync -D` tried and failed to remove `src/electron` but did manage to remove `src/electron/.git` so the subsequent `git remote` calls in `src/electron` actually affected `src/`.