### PR TITLE
fix: e sync, compare paths with no case (#588)

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -18,7 +18,7 @@ function setRemotes(cwd, repo) {
       .trim(),
   );
 
-  if (gitRoot !== cwd) {
+  if (gitRoot.toLowerCase() !== cwd.toLowerCase()) {
     fatal(`Expected git root to be ${cwd} but found ${gitRoot}`);
   }
 


### PR DESCRIPTION
Path returned by `git rev-parse --show-toplevel` after normalizing contain C: drive in upper case, so further string comparison fails  