### PR TITLE
fix: e sync, compare paths with no case on Windows (#588)

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -18,7 +18,10 @@ function setRemotes(cwd, repo) {
       .trim(),
   );
 
-  if (gitRoot !== cwd) {
+  const _match = (process.platform === "win32") ?
+    (gitRoot.toLowerCase() === cwd.toLowerCase()) :
+	(gitRoot === cwd);
+  if (!_match) {
     fatal(`Expected git root to be ${cwd} but found ${gitRoot}`);
   }
 


### PR DESCRIPTION
path returned by `git rev-parse --show-toplevel` on Windows may contain uppercase characters, causing further string comparison to fail. so for Windows platform it's better to compare the string with no case. 