### PR TITLE
fix: handle e pr from wrong repo

### DIFF
--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -59,7 +59,13 @@ async function getPullRequestInfo(pullNumber) {
 }
 
 function guessPRTarget(config) {
-  let script = path.resolve(config.root, 'src', 'electron', 'script', 'lib', 'get-version.js');
+  const electronDir = path.resolve(config.root, 'src', 'electron');
+  if (process.cwd() !== electronDir) {
+    fatal(`You must be in an Electron repository to guess the default target PR branch`);
+  }
+
+  let script = path.resolve(electronDir, 'script', 'lib', 'get-version.js');
+
   if (process.platform === 'win32') {
     script = script.replace(new RegExp(/\\/, 'g'), '\\\\');
   }


### PR DESCRIPTION
We should gracefully handle `e pr` being called in a non-electron repo.

<details><summary>Details</summary>
<p>

```
.electron_build_tools on git:main ❯ e pr                                       5:55PM
fatal: No names found, cannot describe anything.
node:child_process:915
    throw err;
    ^

Error: Command failed: git describe --tags `git rev-list --tags --max-count=1`
fatal: No names found, cannot describe anything.

    at checkExecSyncError (node:child_process:841:11)
    at Object.execSync (node:child_process:912:15)
    at guessPRTarget (/Users/codebytere/.electron_build_tools/src/e-pr.js:72:6)
    at Object.<anonymous> (/Users/codebytere/.electron_build_tools/src/e-pr.js:140:5)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.Module._load (node:internal/modules/cjs/loader:839:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  status: 128,
  signal: null,
  output: [
    null,
    Buffer(0) [Uint8Array] [],
    Buffer(49) [Uint8Array] [
      102,  97, 116,  97, 108,  58,  32,  78, 111,
       32, 110,  97, 109, 101, 115,  32, 102, 111,
      117, 110, 100,  44,  32,  99,  97, 110, 110,
      111, 116,  32, 100, 101, 115,  99, 114, 105,
       98, 101,  32,  97, 110, 121, 116, 104, 105,
      110, 103,  46,  10
    ]
  ],
  pid: 54923,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(49) [Uint8Array] [
    102,  97, 116,  97, 108,  58,  32,  78, 111,
     32, 110,  97, 109, 101, 115,  32, 102, 111,
    117, 110, 100,  44,  32,  99,  97, 110, 110,
    111, 116,  32, 100, 101, 115,  99, 114, 105,
     98, 101,  32,  97, 110, 121, 116, 104, 105,
    110, 103,  46,  10
  ]
}
```

</p>
</details> 

<details><summary>After</summary>
<p>

```
.electron_build_tools on git:gracefully-handle-e-pr ❯ e pr                     5:54PM
ERROR You must be in an Electron repository to guess the default target PR branch
```

</p>
</details> 