### PR TITLE
fix: skip update when BUILD_TOOLS_SHA is set

### DIFF
--- a/src/e
+++ b/src/e
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const childProcess = require('child_process');
+const cp = require('child_process');
 const fs = require('fs');
 const program = require('commander');
 const path = require('path');
@@ -23,10 +23,21 @@ function maybeCheckForUpdates() {
   // should not get a FOO that includes "Checking for build-tools updates".
   const disableAutoUpdatesFile = path.resolve(__dirname, '..', '.disable-auto-updates');
   if (fs.existsSync(disableAutoUpdatesFile)) {
-    console.error(`${color.info} Auto-updates disabled, skipping check for updates`);
+    console.error(`${color.info} Auto-updates disabled - skipping update check`);
     return;
   }
-  // don't check if we already checked recently
+
+  // Skip auto-update check if we checked out a specific commit.
+  const sha = cp.execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  const { BUILD_TOOLS_SHA } = process.env;
+  if (BUILD_TOOLS_SHA === sha) {
+    console.error(
+      `${color.info} build-tools checked out at a specific commit - skipping update check`,
+    );
+    return;
+  }
+
+  // Don't check if we already checked recently
   const intervalHours = 4;
   const updateCheckTSFile = path.resolve(__dirname, '..', '.update');
   const lastCheckEpochMsec = fs.existsSync(updateCheckTSFile)
@@ -42,16 +53,16 @@ function maybeCheckForUpdates() {
   // NB: send updater's stdout to stderr so its log messages are visible
   // but don't pollute stdout. For example, calling `FOO="$(e show exec)"`
   // should not get a FOO that includes "Checking for build-tools updates".
-  childProcess.spawnSync(process.execPath, ['e-auto-update.js'], {
+  cp.spawnSync(process.execPath, ['e-auto-update.js'], {
     cwd: __dirname,
     stdio: [0, 2, 2],
   });
 
-  // update the last-checked-at timestamp
+  // Update the last-checked-at timestamp.
   fs.writeFileSync(updateCheckTSFile, `${Date.now()}`);
 
-  // re-run the current invocation with the updated build-tools
-  const result = childProcess.spawnSync(
+  // Re-run the current invocation with the updated build-tools.
+  const result = cp.spawnSync(
     process.execPath,
     process.argv[0] === process.execPath ? process.argv.slice(1) : process.argv,
     {
@@ -89,7 +100,7 @@ program
       const exec = evmConfig.execOf(evmConfig.current());
       const opts = { stdio: 'inherit' };
       console.log(color.childExec(exec, args, opts));
-      childProcess.execFileSync(exec, args, opts);
+      cp.execFileSync(exec, args, opts);
     } catch (e) {
       fatal(e);
     }
@@ -115,7 +126,7 @@ program
         stdio: 'inherit',
       };
       console.log(color.childExec(exec, args, opts));
-      childProcess.execFileSync(exec, args, opts);
+      cp.execFileSync(exec, args, opts);
     } catch (e) {
       fatal(e);
     }

--- a/src/e-auto-update.js
+++ b/src/e-auto-update.js
@@ -111,14 +111,20 @@ function checkForUpdates() {
     const headCmd = 'rev-parse --verify HEAD';
     const headBefore = git(headCmd);
 
+    const getCurrentCheckout = () => {
+      const branch = git('branch --show-current');
+      const sha = git('rev-parse --short HEAD');
+      return branch === '' ? sha : branch;
+    };
+
     const originUrl = git('remote get-url origin');
     const mainExists = !!git(`ls-remote --heads ${originUrl} main`);
     const desiredBranch = mainExists ? 'main' : 'master';
 
-    const currentBranch = git('branch --show-current');
-    if (currentBranch !== desiredBranch) {
+    const current = getCurrentCheckout();
+    if (current !== desiredBranch) {
       fatal(
-        `build-tools is checked out on ${currentBranch} and not '${desiredBranch}' - please switch and try again.`,
+        `build-tools is checked out on ${current} and not '${desiredBranch}' - please switch and try again.`,
       );
     }
 


### PR DESCRIPTION
We shouldn't check for updates by default if we've set `BUILD_TOOLS_SHA` in order to pin to a sha.

Also fixes an issue where build-tools being checked out on a sha resulted in a broken error:

```
ERROR build-tools is checked out on   and not 'main' - please switch and try again.
```
