### PR TITLE
fix: don't use CircleCI config to find Xcode version

### DIFF
--- a/src/utils/load-xcode.js
+++ b/src/utils/load-xcode.js
@@ -23,7 +23,7 @@ function loadXcode(options = {}) {
     return;
   }
 
-  if (Xcode.ensureXcode(target) === false) {
+  if (Xcode.ensureXcode() === false) {
     return;
   }
 


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/42763.

We shouldn't be using the CircleCI config files to fetch the XCode version necessary for build now they've been removed - use `src/build/mac_toolchain.py` in Chromium only. This is also what we're doing for the associated SDK logic.