### PR TITLE
fix: e start with Chromium

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -31,6 +31,12 @@
       "type": "boolean",
       "default": false
     },
+    "execName": {
+      "description": "Name of the built executable to run",
+      "type": "string",
+      "default": "Electron",
+      "minLength": 1
+    },
     "extends": {
       "description": "Name of base config to extend",
       "type": "string",

--- a/example-configs/evm.chromium.yml
+++ b/example-configs/evm.chromium.yml
@@ -1,6 +1,7 @@
 root: /path/to/chromium/
 reclient: remote_exec
 defaultTarget: chrome
+execName: Chromium
 gen:
   args:
     - use_remoteexec = true


### PR DESCRIPTION
Fixes using `e start` with stock Chromium. `execName` is already supported: https://github.com/electron/build-tools/blob/2f67e10b9b6b5700b1c7940df412b0345257d9ae/src/evm-config.js#L125-L137

But wasn't in the schema.