### PR TITLE
fix: only notify SDK when changed

### DIFF
--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -189,11 +189,11 @@ function ensureSDK() {
     }
 
     evmConfig.setEnvVar(evmConfig.currentName(), 'SDKROOT', eventualVersionedPath);
+
+    console.log(`${color.info} Now using SDK version ${color.path(getSDKVersion())}`);
   }
 
   deleteDir(SDKZip);
-
-  console.log(`${color.info} Now using SDK version ${color.path(getSDKVersion())}`);
 
   return eventualVersionedPath;
 }


### PR DESCRIPTION
Fixes this:

```
electron on git:main ❯ e build                                          3:11PM
INFO Now using SDK version 14.0
INFO Now using SDK version 14.0
INFO Now using SDK version 14.0
Running "/Users/codebytere/.electron_build_tools/third_party/depot_tools/gn gen out/Testing" in /Users/codebytere/Developer/electron-gn/src
Done. Made 21537 targets from 3721 files in 11785ms
Running "autoninja -j 200 electron" in /Users/codebytere/Developer/electron-gn/src/out/Testing
Proxy started successfully.
[0/1] Regenerating ninja files
[22/22] STAMP obj/electron/electron.stamp
RBE Stats: down 0 B, up 0 B, 1 racing local
```