### PR TITLE
fix: mac_toolchain.py won't exist on init

### DIFF
--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -53,8 +53,13 @@ function getSDKVersion() {
   return json.MinimalDisplayName;
 }
 
-function extractSDKVersion(config) {
-  const match = /macOS \d+(?:\.\d+)? SDK\n\# \((\d+\.\d+)/.exec(config);
+function extractSDKVersion(toolchainFile) {
+  if (!fs.existsSync(toolchainFile)) {
+    return null;
+  }
+
+  const contents = fs.readFileSync(toolchainFile, 'utf8');
+  const match = /macOS \d+(?:\.\d+)? SDK\n\# \((\d+\.\d+)/.exec(contents);
   return match ? match[1] : null;
 }
 
@@ -63,18 +68,7 @@ function expectedSDKVersion() {
 
   // The current Xcode version and associated SDK can be found in build/mac_toolchain.py.
   const macToolchainPy = path.resolve(root, 'src', 'build', 'mac_toolchain.py');
-
-  if (!fs.existsSync(macToolchainPy)) {
-    console.warn(
-      color.warn,
-      `Failed to find ${color.path(macToolchainPy)} - falling back to default of`,
-      fallbackSDK(),
-    );
-    return fallbackSDK();
-  }
-
-  const config = fs.readFileSync(macToolchainPy, 'utf8');
-  const version = extractSDKVersion(config);
+  const version = extractSDKVersion(macToolchainPy);
 
   if (isNaN(Number(version)) || !SDKs[version]) {
     console.warn(

--- a/src/utils/xcode.js
+++ b/src/utils/xcode.js
@@ -117,7 +117,7 @@ function expectedXcodeVersion() {
 
   // The current Xcode version and associated SDK can be found in build/mac_toolchain.py.
   const macToolchainPy = path.resolve(root, 'src', 'build', 'mac_toolchain.py');
-  let version = semver.coerce(extractXcodeVersion(macToolchainPy));
+  const version = semver.coerce(extractXcodeVersion(macToolchainPy));
 
   if (isNaN(Number(version)) || !XcodeVersions[version]) {
     console.warn(


### PR DESCRIPTION
Refs https://github.com/electron/build-tools/pull/612

On `e init`, we won't have the source files yet and so `src/build/mac_toolchain.py` won't exist. Use the default Xcode or SDK in this event. Also tighten up some error handling here.