### PR TITLE
fix(evm-config): import `lodash`

### DIFF
--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const Ajv = require('ajv');
+const _ = require('lodash');
 const YAML = require('yaml');
 const { URI } = require('vscode-uri');
 const { color, fatal } = require('./utils/logging');


### PR DESCRIPTION
We're using `_.mergeWith` in this file without importing it.

https://github.com/erickzhao/build-tools/blob/8c95e2259a1085362b6e78fdffb88480c28d6e49/src/evm-config.js#L144-L148