### PR TITLE
fix: handle reclient helper failure gracefully

### DIFF
--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -108,10 +108,17 @@ function reclientEnv(config) {
   const result = childProcess.spawnSync(reclientHelperPath, ['flags'], {
     stdio: 'pipe',
   });
+
   if (result.status === 0) {
-    const extraArgs = JSON.parse(result.stdout.toString());
-    reclientEnv = Object.assign(reclientEnv, extraArgs);
+    try {
+      const extraArgs = JSON.parse(result.stdout.toString());
+      reclientEnv = Object.assign(reclientEnv, extraArgs);
+    } catch (e) {
+      console.error(result.stdout.toString());
+      fatal('Failure to run reclient credential helper');
+    }
   }
+
   return reclientEnv;
 }
 


### PR DESCRIPTION
Handle failure gracefully:
```
SyntaxError: Unexpected token U in JSON at position 0
    at JSON.parse (<anonymous>)
    at Object.reclientEnv [as env] (reclient.js:112:28)
```