### PR TITLE
docs: improve e build --target documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Some of the build targets you may want to build include:
 | electron:node_headers  | Builds the node headers `.tar.gz` file          |
 | electron:electron_symbols  | Generate the breakpad symbols in release builds     |
 
-To build a specific target, run `e build --target [target]`. Running `e build` with no
+To build a specific ninja target, run `e build --target [target]`. Running `e build` with no
 target will build `electron` by default.
 
 Any extra args are passed along to [ninja][ninja], so for example

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ $ e build --help
 ```
 
 Once you have the source, the next step is to build it with `e build [target]`.
-These build targets are supported:
+Some of the build targets you may want to build include:
 
 | Target        | Description                                              |
 |:--------------|:---------------------------------------------------------|
@@ -204,11 +204,44 @@ These build targets are supported:
 | electron      | Builds the Electron binary **(Default)**                 |
 | electron:dist | Builds the Electron binary and generates a dist zip file |
 | mksnapshot    | Builds the `mksnapshot` binary                           |
-| node:headers  | Builds the node headers `.tar.gz` file                   |
+| electron:node_headers  | Builds the node headers `.tar.gz` file          |
+| electron:electron_symbols  | Generate the breakpad symbols in release builds     |
 
-As with syncing, `e build [target]` is usually all you need. Any extra
-args are passed along to [ninja][ninja], so for example `e build -v`
-runs a verbose build.
+To build a specific target, run `e build --target [target]`. Running `e build` with no
+target will build `electron` by default.
+
+Any extra args are passed along to [ninja][ninja], so for example
+`e build -v` runs a verbose build.
+
+To see an exhaustive list of all possible build targets, you can run `e d gn ls out/[TYPE]`,
+where `[TYPE]` is e.g. `Testing` or `Release` depending on your build type. This will log a long
+list of targets to the console and also allow you to build some of Chromium's targets.
+
+For example, running `e d gn ls out/Testing | grep "//ui/views/"` produces something like:
+
+```console
+//ui/views/controls/webview:test_support
+//ui/views/controls/webview:webview
+//ui/views/debug:views_debug
+//ui/views/examples:copy_content_resources
+//ui/views/examples:views_examples
+//ui/views/examples:views_examples_lib
+//ui/views/examples:views_examples_proc
+//ui/views/examples:views_examples_resources_grd
+//ui/views/examples:views_examples_resources_grd_grit
+//ui/views/examples:views_examples_resources_pak
+//ui/views/examples:views_examples_unittests
+//ui/views/examples:views_examples_unittests__runner
+//ui/views/examples:views_examples_with_content
+//ui/views/examples:views_examples_with_content_lib
+//ui/views/resources:resources
+//ui/views/resources:resources_grd
+//ui/views/resources:resources_grd_grit
+//ui/views/window/vector_icons:vector_icons
+//ui/views/window/vector_icons:window_control_vector_icons
+```
+
+You could then run `e build --target ui/views/examples:views_examples_with_content` to produce Chrome's `//ui/views` example executable and run it with `./out/Testing/views_examples_with_content`.
 
 ## Using Electron
 

--- a/README.md
+++ b/README.md
@@ -199,19 +199,24 @@ Some of the build targets you may want to build include:
 
 | Target        | Description                                              |
 |:--------------|:---------------------------------------------------------|
-| breakpad      | Builds the breakpad `dump_syms` binary                   |
-| chromedriver  | Builds the `chromedriver` binary                         |
-| electron      | Builds the Electron binary **(Default)**                 |
-| electron:dist | Builds the Electron binary and generates a dist zip file |
-| mksnapshot    | Builds the `mksnapshot` binary                           |
-| electron:node_headers  | Builds the node headers `.tar.gz` file          |
-| electron:electron_symbols  | Generate the breakpad symbols in release builds     |
+| third_party/breakpad:dump_syms      | Builds the breakpad `dump_syms` binary                   |
+| electron:electron_chromedriver_zip  | Builds the `chromedriver` binary                         |
+| electron                            | Builds the Electron binary **(Default)**                 |
+| electron:electron_dist_zip          | Builds the Electron binary and generates a dist zip file |
+| electron:electron_mksnapshot_zip    | Builds the `mksnapshot` binary                           |
+| electron:node_headers               | Builds the node headers `.tar.gz` file                   |
+| electron:electron_symbols           | Generate the breakpad symbols in release builds          |
 
-To build a specific ninja target, run `e build --target [target]`. Running `e build` with no
-target will build `electron` by default.
+To build a specific ninja target, run `e build --target [target]`:
+
+```sh
+$ e build --target electron:node_headers
+```
+
+Running `e build` with no target will build `electron` by default.
 
 Any extra args are passed along to [ninja][ninja], so for example
-`e build -v` runs a verbose build.
+`e build -v` runs a verbose build of `electron`.
 
 To see an exhaustive list of all possible build targets, you can run `e d gn ls out/[TYPE]`,
 where `[TYPE]` is e.g. `Testing` or `Release` depending on your build type. This will log a long

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -77,7 +77,7 @@ function runGClientSync(syncArgs, syncOpts) {
   }
 
   // Only set remotes if we're building an Electron target.
-  if (config.defaultTarget !== evmConfig.buildTargets().chromium) {
+  if (config.defaultTarget !== 'chrome') {
     const electronPath = path.resolve(srcdir, 'electron');
     setRemotes(electronPath, config.remotes.electron);
   }

--- a/src/evm-config.js
+++ b/src/evm-config.js
@@ -32,17 +32,6 @@ const getDefaultTarget = () => {
   return result || 'electron';
 };
 
-const buildTargets = () => ({
-  breakpad: 'third_party/breakpad:dump_syms',
-  chromedriver: 'electron:electron_chromedriver_zip',
-  electron: 'electron',
-  chromium: 'chrome',
-  'electron:dist': 'electron:electron_dist_zip',
-  mksnapshot: 'electron:electron_mksnapshot_zip',
-  'node:headers': 'electron:node_headers',
-  default: getDefaultTarget(),
-});
-
 function buildPath(name, suffix) {
   return path.resolve(configRoot(), `evm.${name}.${suffix}`);
 }
@@ -319,7 +308,7 @@ function remove(name) {
 }
 
 module.exports = {
-  buildTargets,
+  getDefaultTarget,
   current: () => sanitizeConfigWithName(currentName()),
   maybeCurrent: () => (getCurrentFileName() ? sanitizeConfigWithName(currentName()) : {}),
   currentName,

--- a/src/utils/load-xcode.js
+++ b/src/utils/load-xcode.js
@@ -10,7 +10,6 @@ const Xcode = require('./xcode');
 const evmConfig = require('../evm-config');
 
 function loadXcode(options = {}) {
-  const target = options.target || 'electron';
   const quiet = options.quiet || false;
 
   if (process.platform !== 'darwin') {


### PR DESCRIPTION
This PR adds some improvements to the `e build` documentation to clarify passing `--target` as well as how to see/use possible build targets.