### PR TITLE
fix: `buildTargets` are gone now

### DIFF
--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -77,7 +77,7 @@ function runGClientSync(syncArgs, syncOpts) {
   }
 
   // Only set remotes if we're building an Electron target.
-  if (config.defaultTarget !== evmConfig.buildTargets().chromium) {
+  if (config.defaultTarget !== 'chrome') {
     const electronPath = path.resolve(srcdir, 'electron');
     setRemotes(electronPath, config.remotes.electron);
   }


### PR DESCRIPTION
Refs https://github.com/electron/build-tools/pull/635.