### PR TITLE
fix: handle `getCveForBugNr` failure

### DIFF
--- a/src/utils/crbug.js
+++ b/src/utils/crbug.js
@@ -78,14 +78,14 @@ function parseCveFromIssue(issue) {
 
 async function getCveForBugNr(bugNr) {
   if (Number.isNaN(bugNr)) {
-    fatal(`Invalid Chromium bug number ${bugNr}`);
+    throw new Error(`Invalid Chromium bug number ${bugNr}`);
   }
 
   try {
     const issue = await getBugInfo(bugNr);
     return parseCveFromIssue(issue);
   } catch (error) {
-    fatal(error);
+    throw new Error(`Failed to fetch CVE for ${bugNr} - ${error}`);
   }
 }
 


### PR DESCRIPTION
Allows continuing to create the PR if CVE parsing fails in Chromium's Issue Tracker:

```
electron on git:30-x-y ❯ e cherry-pick --security https://chromium-review.googlesource.com/c/chromium/src/+/5402199 30-x-y
WARN Failed to fetch CVE for 330756841 - you'll need to find it manually
```