### PR TITLE
fix: e test after aliases change

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -10,15 +10,7 @@
     "defaultTarget": {
       "description": "Default build target",
       "type": "string",
-      "enum": [
-        "breakpad",
-        "chromedriver",
-        "electron",
-        "electron:dist",
-        "mksnapshot",
-        "node:headers",
-        "chrome"
-      ]
+      "default": "electron"
     },
     "preserveXcode": {
       "description": "Preserve the N most recent Xcode versions",

--- a/src/e-test.js
+++ b/src/e-test.js
@@ -41,7 +41,7 @@ program
   .option('--nan', 'Run nan spec runner', false)
   .option(
     '--no-remote',
-    'Build test runner components (e.g. node:headers) without remote execution',
+    'Build test runner components (e.g. electron:node_headers) without remote execution',
   )
   .addOption(
     new program.Option(

--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -23,7 +23,7 @@ function ensureNodeHeaders(config, useRemote) {
 
   if (needs_build) {
     const exec = process.execPath;
-    const args = [path.resolve(__dirname, '..', 'e'), 'build', 'node:headers'];
+    const args = [path.resolve(__dirname, '..', 'e'), 'build', 'electron:node_headers'];
     if (!useRemote) args.push('--no-remote');
 
     const opts = { stdio: 'inherit', encoding: 'utf8' };


### PR DESCRIPTION
Refs https://github.com/electron/build-tools/pull/635

Fixes broken `e test` with old header alias.