### PR TITLE
fix: `getGitHubAuthToken` scope handling

### DIFF
--- a/src/utils/github-auth.js
+++ b/src/utils/github-auth.js
@@ -28,10 +28,12 @@ async function getGitHubAuthToken(scopes = []) {
     const authStatus = runGhCliCommand(['auth', 'status']);
 
     // Check that the scopes on the token include the requested scopes
-    const regexMatch = authStatus.match(/^.*Token scopes: (.*)$/gm);
+    const regexMatch = authStatus.match(/^.*Token scopes: (.*)$/m);
 
     if (regexMatch) {
-      const tokenScopes = regexMatch[0].split(',').map(scope => scope.trim());
+      const tokenScopes = regexMatch[1]
+        .split(',')
+        .map(item => item.trim().replace(/^'(.*)'$/, '$1'));
 
       if (scopes.every(scope => tokenScopes.includes(scope))) {
         return runGhCliCommand(['auth', 'token']).trim();


### PR DESCRIPTION
Fixes an issue where I would be repeatedly asked for token authentication despite authenticating successfully previously.

This was rooted in two issues:

1) `String.prototype.match()` won't return capture groups if the `g` flag is set - so the result of the `match` was an array with one value: `[ "- Token scopes: 'gist'", "'read:org'", "'repo'", "'workflow'" ]`
2) The quotes weren't being parsed out correctly, so the scopes were being checked as `"'read:org'"` instead of `read:org` which would incorrectly return false.

After this change, `tokenScopes` is `[ 'gist', 'read:org', 'repo', 'workflow' ]` as expected, which prevents the issue.