### PR TITLE
fix: macOS SDK parsing regex

### DIFF
--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -57,14 +57,20 @@ function getSDKVersion() {
   return json.MinimalDisplayName;
 }
 
+// Extract the SDK version from the toolchain file and normalize it.
 function extractSDKVersion(toolchainFile) {
   if (!fs.existsSync(toolchainFile)) {
     return null;
   }
 
   const contents = fs.readFileSync(toolchainFile, 'utf8');
-  const match = /macOS \d+(?:\.\d+)? SDK\n\# \((\d+\.\d+)/.exec(contents);
-  return match ? match[1] : null;
+  const match = /macOS\s(\d+(\.\d+)?)\sSDK\n\#/.exec(contents);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[1].includes('.') ? match[1] : `${match[1]}.0`;
 }
 
 function expectedSDKVersion() {


### PR DESCRIPTION
Fixes the regex to match all recent formats seen in `build/mac_toolchain.py`

```py
# This contains binaries from Xcode 14.0 14B47b along with the macOS 13 SDK
# (13.0 22A372). To build these packages, see comments in
# build/xcode_binaries.yaml
```
```py
# This contains binaries from Xcode 15.0 15A240d along with the macOS 14.0 SDK
# (14.0 23A334). To build these packages, see comments in
# build/xcode_binaries.yaml
# To update the version numbers, open Xcode's "About Xcode" for the first number
# and run `xcrun --show-sdk-build-version` for the second.
# To update the _TAG, use the output of the `cipd create` command mentioned in
# xcode_binaries.yaml.
```
```py
# This contains binaries from Xcode 16.0 16A242d along with the macOS 15.0 SDK
# (24A336). To build these packages, see comments in build/xcode_binaries.yaml.
# To update the version numbers, open Xcode's "About Xcode" for the first number
# and run `xcrun --show-sdk-build-version` for the second. To update the _TAG,
# use the output of the `cipd create` command mentioned in xcode_binaries.yaml.
```

In this above, we would successfully parse 13, 14.0, and 15.0 as 13.0, 14.0, and 15.0.
