### PR TITLE
fix: fetch latest base ref to ensure merge sha is local

### DIFF
--- a/src/e-backport.js
+++ b/src/e-backport.js
@@ -77,6 +77,12 @@ program
       return;
     }
 
+    const ensureMergeRefLocal = spawnSync(config, 'git', ['fetch', 'origin', pr.base.ref], gitOpts);
+    if (ensureMergeRefLocal.status !== 0) {
+      fatal('Failed to fetch latest upstream');
+      return;
+    }
+
     const manualBpBranch = `manual-bp/${user.login}/pr/${prNumber}/branch/${targetBranch}`;
     spawnSync(config, 'git', ['branch', '-D', manualBpBranch], gitOpts);
     const backportBranchResult = spawnSync(


### PR DESCRIPTION
This fixes an issue I keep running into where I run `e backport` immediately after merging the original PR, it bails because the sha it's trying to cherry pick isn't local yet because I haven't run `git fetch` or `git pull` for the base ref.