### PR TITLE
fix: reclient support for non-experimental cred helper

### DIFF
--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -104,6 +104,8 @@ function reclientEnv(config) {
 
   let reclientEnv = {
     RBE_service: config.reclientServiceAddress || rbeServiceAddress,
+    RBE_credentials_helper: getHelperPath(config),
+    RBE_credentials_helper_args: 'print',
     RBE_experimental_credentials_helper: getHelperPath(config),
     RBE_experimental_credentials_helper_args: 'print',
   };


### PR DESCRIPTION
Upstream will pick https://github.com/bazelbuild/reclient/commit/4017a6c8b46c6ad9cd15932d97607a4065a9b26a up soon and when they do we want build tools to keep working.