### PR TITLE
feat: handle sdk-only clean set up without xcode

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -175,6 +175,15 @@ program
         checkGlobalGitConfig();
       }
 
+      // ensure xcode is loaded
+      if (process.platform === 'darwin') {
+        if (options.onlySdk) {
+          ensureSDK();
+        } else {
+          loadXcode();
+        }
+      }
+
       const config = createConfig(options);
 
       // make sure the config name is new
@@ -198,15 +207,6 @@ program
       const e = path.resolve(__dirname, 'e');
       const opts = { stdio: 'inherit' };
       childProcess.execFileSync(process.execPath, [e, 'use', name], opts);
-
-      // ensure xcode is loaded
-      if (process.platform === 'darwin') {
-        if (options.onlySdk) {
-          ensureSDK();
-        } else {
-          loadXcode();
-        }
-      }
 
       ensureRoot(config, !!options.force);
 

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -9,6 +9,7 @@ const { fatal } = require('./utils/logging');
 const { ensureDir } = require('./utils/paths');
 const depot = require('./utils/depot-tools');
 const { configureReclient } = require('./utils/setup-reclient-chromium');
+const { ensureSDK } = require('./utils/sdk');
 
 function setRemotes(cwd, repo) {
   // Confirm that cwd is the git root
@@ -54,6 +55,12 @@ function runGClientSync(syncArgs, syncOpts) {
   }
 
   depot.ensure();
+
+  if (process.platform === 'darwin') {
+    if (config.onlySdk) {
+      ensureSDK();
+    }
+  }
 
   if (config.defaultTarget === 'chrome') {
     configureReclient();

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -1,4 +1,5 @@
 const cp = require('child_process');
+const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
@@ -94,6 +95,25 @@ function expectedSDKVersion() {
   return version;
 }
 
+function ensureViableXCode() {
+  const xcodeBuildExec = '/usr/bin/xcodebuild';
+  if (fs.existsSync(xcodeBuildExec)) {
+    const result = cp.spawnSync(xcodeBuildExec, ['-version']);
+    if (result.status === 0) return;
+  }
+
+  fatal(`Xcode appears to be missing, you may have Command Line Tools installed but not a full Xcode. Please install Xcode now...
+
+You can get Xcode from the app store: ${chalk.cyan(
+    'https://apps.apple.com/us/app/xcode/id497799835',
+  )}
+Or directly from Apple Developer: ${chalk.cyan('https://developer.apple.com/xcode')}
+
+You can validate your install with "${chalk.green(
+    '/usr/bin/xcodebuild -version',
+  )}" once you are ready or just run this command again`);
+}
+
 function ensureSDKAndSymlink(config) {
   const localPath = ensureSDK();
 
@@ -117,6 +137,8 @@ function ensureSDK() {
     console.log('TEST: ensureSDK called');
     return;
   }
+
+  ensureViableXCode();
 
   const expected = expectedSDKVersion();
   const eventualVersionedPath = path.resolve(SDKDir, `MacOSX${expected}.sdk`);

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -109,6 +109,12 @@ You can get Xcode from the app store: ${chalk.cyan(
   )}
 Or directly from Apple Developer: ${chalk.cyan('https://developer.apple.com/xcode')}
 
+If you have Xcode downloaded and are still seeing this make sure you have:
+  1. Opened Xcode at least once and gotten to the "Create new project" screen
+  2. Switched to your installed Xcode with ${chalk.green(
+    'sudo xcode-select -s /Applications/Xcode.app',
+  )}
+
 You can validate your install with "${chalk.green(
     '/usr/bin/xcodebuild -version',
   )}" once you are ready or just run this command again`);


### PR DESCRIPTION
This nicely handles the user not having a full xcode install (and just command line instead). Tested / written while setting up my new laptop 😅 

This also ensures that during `e init` if we hard bail for Xcode we do it as early as possible.

<img width="914" alt="image" src="https://github.com/user-attachments/assets/402ebc62-a2ab-40a8-b784-58e6595e9885">
