### PR TITLE
fix: early RBE failure building Chromium

### DIFF
--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -110,6 +110,13 @@ function reclientEnv(config) {
     RBE_experimental_credentials_helper_args: 'print',
   };
 
+  // When building Chromium, don't fail early on local fallbacks
+  // as they are expected.
+  if (config.defaultTarget === 'chrome') {
+    reclientEnv.RBE_fail_early_min_action_count = 0;
+    reclientEnv.RBE_fail_early_min_fallback_ratio = 0;
+  }
+
   const result = childProcess.spawnSync(reclientHelperPath, ['flags'], {
     stdio: 'pipe',
   });


### PR DESCRIPTION
Fixes the following seen when building Chromium with build-tools:

```
reclient[f2fe214d-088a-45ba-a536-22bed7df2d61]: LocalErrorResultStatus: this build has encountered too many local fallbacks. This means that the ratio of actions that failed remotely is equal to or above the preconfigured threshold of 50.0%
```