### PR TITLE
chore: fix ensureSDK when calling e init for the first time

### DIFF
--- a/src/e-init.js
+++ b/src/e-init.js
@@ -168,11 +168,6 @@ program
         checkGlobalGitConfig();
       }
 
-      // ensure macOS SDKs are loaded
-      if (process.platform === 'darwin') {
-        ensureSDK();
-      }
-
       const config = createConfig(options);
 
       // make sure the config name is new
@@ -196,6 +191,11 @@ program
       const e = path.resolve(__dirname, 'e');
       const opts = { stdio: 'inherit' };
       childProcess.execFileSync(process.execPath, [e, 'use', name], opts);
+
+      // ensure macOS SDKs are loaded
+      if (process.platform === 'darwin') {
+        ensureSDK();
+      }
 
       ensureRoot(config, !!options.force);
 


### PR DESCRIPTION
- #653 broke e init on a fresh install on macOS because `ensureSDK` needs a current config written before running.  This fixes that error.