### PR TITLE
fix: cherry-pick command

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -152,7 +152,7 @@ program
     try {
       const {
         data: { permissions },
-      } = await octokit.repos.get(...ELECTRON_REPO_DATA);
+      } = await octokit.repos.get(ELECTRON_REPO_DATA);
 
       if (!permissions?.push) {
         fatal(


### PR DESCRIPTION
Follow-up to #643, this is currently throwing a `TypeError` since it's destructuring an object into an argument list.