### PR TITLE
fix: remove `onlySdk` checks

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -15,7 +15,7 @@ const { ensureSDK, ensureSDKAndSymlink } = require('./utils/sdk');
 function getGNArgs(config) {
   const configArgs = config.gen.args;
 
-  if (config.onlySdk && process.platform === 'darwin') {
+  if (process.platform === 'darwin') {
     configArgs.push(`mac_sdk_path = "${ensureSDKAndSymlink(config)}"`);
   }
 

--- a/src/e-sync.js
+++ b/src/e-sync.js
@@ -57,9 +57,7 @@ function runGClientSync(syncArgs, syncOpts) {
   depot.ensure();
 
   if (process.platform === 'darwin') {
-    if (config.onlySdk) {
-      ensureSDK();
-    }
+    ensureSDK();
   }
 
   if (config.defaultTarget === 'chrome') {

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -90,10 +90,6 @@ function eInitRunner(execOptions) {
       args.push('--out', val);
       return o;
     },
-    onlySdk: () => {
-      args.push('--only-sdk');
-      return o;
-    },
     root: val => {
       args.push('--root', val);
       return o;


### PR DESCRIPTION
This is redundant after https://github.com/electron/build-tools/pull/617.

The only place this should be checked is config sanitization.