### PR TITLE
fix: mac_sdk_path double-adding

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -16,7 +16,10 @@ function getGNArgs(config) {
   const configArgs = config.gen.args;
 
   if (process.platform === 'darwin') {
-    configArgs.push(`mac_sdk_path = "${ensureSDKAndSymlink(config)}"`);
+    const sdkArg = `mac_sdk_path = "${ensureSDKAndSymlink(config)}"`;
+    if (!configArgs.includes(sdkArg)) {
+      configArgs.push(sdkArg);
+    }
   }
 
   // GN_EXTRA_ARGS is a list of GN args to append to the default args.


### PR DESCRIPTION
`getGNArgs` is called miltiple places in the codebase, and we weren't checking to see if the sdk path was added already, which resulted in it being duplicated:


```gn
import("//electron/build/args/testing.gn")
use_remoteexec=true
mac_sdk_path = "//out/Testing/xcode_links/electron/MacOSX15.0.sdk"
mac_sdk_path = "//out/Testing/xcode_links/electron/MacOSX15.0.sdk"
```

This fixes that