### PR TITLE
fix: allow disable download windows toolchain on windows platform

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -57,7 +57,7 @@ function platformOpts() {
   let opts = {};
 
   const winToolchainOverride = process.env.ELECTRON_DEPOT_TOOLS_WIN_TOOLCHAIN;
-  if (os.platform() === 'win32' || winToolchainOverride === '1') {
+  if ((os.platform() === 'win32' && winToolchainOverride !== '0') || winToolchainOverride === '1') {
     opts = {
       DEPOT_TOOLS_WIN_TOOLCHAIN: '1',
       DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL: 'https://dev-cdn.electronjs.org/windows-toolchains/_',


### PR DESCRIPTION
I think it is reasonable for _**local development only**_ that use local VS instead of downloading a huge blob from electron's cdn.

This indeed benefits binary consistency and CI, but seems not important for contributors to develop locally, so perhaps we can disable it by set `ELECTRON_DEPOT_TOOLS_WIN_TOOLCHAIN` to `0`, since this feature is kind of hidden, the developer knows what they are doing.

Even in [official docs](https://www.electronjs.org/docs/latest/development/build-instructions-gn#gn-prerequisites) wants contributing developers to use local toolchain instead of downloading, so I think it should be all right to disable here.