### PR TITLE
feat: 'e clean' for removing artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 artifacts
 configs
 coverage
+local-storage.json
 node_modules
 package-lock.json
 third_party

--- a/src/e
+++ b/src/e
@@ -179,7 +179,8 @@ program
     'Opens a PR to electron/electron that backport the given CL into our patches folder',
   )
   .alias('auto-cherry-pick')
-  .command('gh-auth', 'Generates a device oauth token');
+  .command('gh-auth', 'Generates a device oauth token')
+  .command('clean', 'Cleanup artifacts produced by build tools');
 
 const ci = program.command('ci').executableDir(path.join(__dirname, 'ci'));
 ci.command('status', 'Show information about CI job statuses');

--- a/src/e-clean.js
+++ b/src/e-clean.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { ARTIFACTS_DIR, getStaleArtifacts } = require('./utils/artifacts');
+
+const program = require('commander');
+const { color, fatal } = require('./utils/logging');
+
+function clean(options) {
+  try {
+    if (options.stale) {
+      const staleFiles = getStaleArtifacts();
+      staleFiles.forEach((file) => {
+        const filePath = path.join(ARTIFACTS_DIR, file);
+        fs.rmSync(filePath, { recursive: true, force: true });
+      });
+      console.log(color.success, `${staleFiles.length} stale artifact(s) removed.`);
+    } else {
+      fs.rmSync(ARTIFACTS_DIR, { recursive: true, force: true });
+      console.log(color.success, 'Artifacts directory cleaned successfully.');
+    }
+  } catch (error) {
+    fatal(error);
+  }
+}
+
+program.action(clean).option('--stale', 'Only clean stale artifacts');
+
+program.parse(process.argv);

--- a/src/e-pr.js
+++ b/src/e-pr.js
@@ -15,6 +15,7 @@ const inquirer = require('inquirer');
 const { getGitHubAuthToken } = require('./utils/github-auth');
 const { current } = require('./evm-config');
 const { color, fatal } = require('./utils/logging');
+const { ARTIFACTS_DIR, maybeCheckStaleArtifacts } = require('./utils/artifacts');
 
 const d = require('debug')('build-tools:pr');
 
@@ -217,6 +218,8 @@ program
       fatal(`Pull request number is required to download a PR`);
     }
 
+    maybeCheckStaleArtifacts();
+
     d('checking auth...');
     const octokit = new Octokit({
       auth: await getGitHubAuthToken(['repo']),
@@ -311,9 +314,8 @@ Proceed?`,
         return;
       }
     } else {
-      const artifactsDir = path.resolve(__dirname, '..', 'artifacts');
       const defaultDir = path.resolve(
-        artifactsDir,
+        ARTIFACTS_DIR,
         `pr_${pullRequest.number}_${options.platform}_${options.arch}`,
       );
 

--- a/src/utils/artifacts.js
+++ b/src/utils/artifacts.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const { localStorage } = require('./local-storage');
+const fs = require('fs');
+
+const ARTIFACTS_DIR = path.join(__dirname, '..', '..', 'artifacts');
+
+/** How often to check for stale files. */
+const STALE_CHECK_INTERVAL = 7 * 24 * 60 * 60 * 1000; // 1 week
+
+/** How old a file is to be considered stale. */
+const STALE_FILE_AGE = 30 * 24 * 60 * 60 * 1000; // 1 month
+
+function getStaleArtifacts() {
+  const now = Date.now();
+  let files;
+  try {
+    files = fs.readdirSync(ARTIFACTS_DIR);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+    return [];
+  }
+  const staleFiles = files.filter((file) => {
+    const filePath = path.join(ARTIFACTS_DIR, file);
+    const stats = fs.statSync(filePath);
+    return stats.mtimeMs < now - STALE_FILE_AGE;
+  });
+  return staleFiles;
+}
+
+function maybeCheckStaleArtifacts() {
+  const lastChecked = parseInt(localStorage.getItem('lastArtifactsCheck'), 10);
+  const now = Date.now();
+
+  if (!lastChecked || lastChecked < now - STALE_CHECK_INTERVAL) {
+    const staleArtifacts = getStaleArtifacts();
+    if (staleArtifacts.length > 0) {
+      console.warn(
+        `Stale artifact(s) found:\n\t${staleArtifacts.join('\n\t')}\n\nRun 'e clean --stale' to cleanup artifacts.`,
+      );
+    }
+    localStorage.setItem('lastArtifactsCheck', now);
+  }
+}
+
+module.exports = {
+  ARTIFACTS_DIR,
+  getStaleArtifacts,
+  maybeCheckStaleArtifacts,
+};

--- a/src/utils/local-storage.js
+++ b/src/utils/local-storage.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Simple localStorage implementation before it becomes widely available in NodeJS.
+ * https://github.com/nodejs/node/blob/main/doc/api/globals.md#localstorage
+ */
+class LocalStorage {
+  constructor() {
+    this.filePath = path.resolve(__dirname, '..', '..', 'local-storage.json');
+  }
+
+  #load() {
+    try {
+      return JSON.parse(fs.readFileSync(this.filePath, 'utf8'));
+    } catch {
+      return {};
+    }
+  }
+
+  #save() {
+    fs.writeFileSync(this.filePath, JSON.stringify(this.store, null, 2));
+  }
+
+  /** Lazy-load reading from disk. */
+  get store() {
+    return (this.store = this.#load());
+  }
+  set store(value) {
+    Object.defineProperty(this, 'store', { value });
+  }
+
+  getItem(key) {
+    return this.store[key];
+  }
+
+  setItem(key, value) {
+    this.store[key] = JSON.stringify(value);
+    this.#save();
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+    this.#save();
+  }
+
+  clear() {
+    this.store = {};
+    this.#save();
+  }
+
+  key(index) {
+    return Object.keys(this.store)[index];
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+}
+
+const localStorage = new LocalStorage();
+
+module.exports = {
+  localStorage,
+};


### PR DESCRIPTION
Breaking this out as I think this warrants more discussion.

https://github.com/electron/build-tools/pull/679 introduces an `artifacts/` directory for downloading pull request artifacts. To mitigate this directory growing indefinitely, I'm proposing `e clean` and `e clean --stale`.

- `e clean` will remove the `artifacts/` directory
- `e clean --stale` removes only top-level stale files in `artifacts/` (older than one month)

-----

So folks are aware of these commands existence—and that stale files exist—we can display a warning.

```
$ e pr download-dist 44653
Stale artifact(s) found:
        pr_44653_darwin_arm64

Run 'e clean --stale' to cleanup artifacts.
```

This presents the question of how often and when to display this warning.

#### A. Warn about stale files each time `e pr download-dist` is run

- Check for stale files and log warning

#### B. Warn about stale files warning on `e` startup

- Every time build-tools is invoked, we check for stale files and report on them
- To prevent spam, only warn once a week.
- `localStorage` API for caching state

-----

Maybe this all too complex and we shouldn't do this at all? Open to feedback.