### PR TITLE
chore: enable help option for e debug

### DIFF
--- a/src/e-debug.js
+++ b/src/e-debug.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
 const childProcess = require('child_process');
-const commandExistsSync = require('command-exists').sync;
 const path = require('path');
+
+const { sync: commandExistsSync } = require('command-exists');
+const program = require('commander');
 
 const evmConfig = require('./evm-config');
 const { fatal } = require('./utils/logging');
@@ -11,6 +13,10 @@ const opts = {
   encoding: 'utf8',
   stdio: 'inherit',
 };
+
+program
+  .description('Run the Electron build with a debugger (gdb or lldb)')
+  .action(debug);
 
 function run_gdb(config) {
   const electron = evmConfig.execOf(config);
@@ -31,22 +37,26 @@ function run_lldb(config) {
   childProcess.execFileSync('lldb', args, opts);
 }
 
-try {
-  const choices = [
-    { exec: 'gdb', runner: run_gdb },
-    { exec: 'lldb', runner: run_lldb },
-  ];
+function debug() {
+  try {
+    const choices = [
+      { exec: 'gdb', runner: run_gdb },
+      { exec: 'lldb', runner: run_lldb },
+    ];
 
-  const choice = choices.find((choice) => commandExistsSync(choice.exec));
-  if (choice) {
-    choice.runner(evmConfig.current());
-  } else {
-    fatal(
-      `No debugger found in PATH! Looked for [${choices
-        .map((choice) => `'${choice.exec}'`)
-        .join(', ')}]`,
-    );
+    const choice = choices.find((choice) => commandExistsSync(choice.exec));
+    if (choice) {
+      choice.runner(evmConfig.current());
+    } else {
+      fatal(
+        `No debugger found in PATH! Looked for [${choices
+          .map((choice) => `'${choice.exec}'`)
+          .join(', ')}]`,
+      );
+    }
+  } catch (e) {
+    fatal(e);
   }
-} catch (e) {
-  fatal(e);
 }
+
+program.parse(process.argv);

--- a/src/e-debug.js
+++ b/src/e-debug.js
@@ -14,9 +14,7 @@ const opts = {
   stdio: 'inherit',
 };
 
-program
-  .description('Run the Electron build with a debugger (gdb or lldb)')
-  .action(debug);
+program.description('Run the Electron build with a debugger (gdb or lldb)').action(debug);
 
 function run_gdb(config) {
   const electron = evmConfig.execOf(config);


### PR DESCRIPTION
Ensures `e debug -h` outputs useful output instead of launching into the command