### PR TITLE
fix: RBE untrusted step for Chromium building

### DIFF
--- a/src/utils/setup-reclient-chromium.js
+++ b/src/utils/setup-reclient-chromium.js
@@ -73,19 +73,48 @@ function configureReclient() {
       fatal('Failed to apply EngFlow reclient configs patch');
     }
 
-    const configureConfigScript = path.join(engflowConfigsDir, 'configure_reclient.py');
-    const { status: configureStatus } = spawnSync(
+    const configureReclientScript = path.join(engflowConfigsDir, 'configure_reclient.py');
+    const { status: configureReclientStatus } = spawnSync(
       evmConfig.current(),
       'python3',
-      [configureConfigScript, '--src_dir=src', '--force'],
+      [configureReclientScript, '--src_dir=src', '--force'],
       {
         cwd: root,
         stdio: 'inherit',
       },
     );
 
-    if (configureStatus !== 0) {
+    if (configureReclientStatus !== 0) {
       fatal('Failed to configure EngFlow reclient configs');
+    }
+
+    const configureConfigScript = path.join(
+      srcDir,
+      'buildtools',
+      'reclient_cfgs',
+      'configure_reclient_cfgs.py',
+    );
+    const { status: configureConfigStatus } = spawnSync(
+      evmConfig.current(),
+      'python3',
+      [
+        configureConfigScript,
+        '--rbe_instance',
+        'projects/rbe-chrome-untrusted/instances/default_instance',
+        '--reproxy_cfg_template',
+        'reproxy.cfg.template',
+        '--rewrapper_cfg_project',
+        '',
+        '--skip_remoteexec_cfg_fetch',
+      ],
+      {
+        cwd: root,
+        stdio: 'inherit',
+      },
+    );
+
+    if (configureConfigStatus !== 0) {
+      fatal('Failed to configure RBE config scripts for untrusted RBE');
     }
 
     console.info(`${color.info} Successfully configured EngFlow reclient configs for Chromium`);


### PR DESCRIPTION
Without this step building Chromium will result in the following error:

```
src on git:main ❯ e build
Running "autoninja -j 200 chrome" in /Users/codebytere/Developer/chromium/src/out/Default
You can't use rbe-chrome-untrusted on non-corp machine.
Please use rbe-chromium-untrusted and non-@google.com account instead to build chromium.
ERROR Error: Command failed: autoninja -j 200 chrome
```

cc @dsanders11 