### PR TITLE
chore: remove outdated Python2 workaround for Apple Silicon

### DIFF
--- a/src/utils/depot-tools.js
+++ b/src/utils/depot-tools.js
@@ -105,15 +105,6 @@ function depotOpts(config, opts = {}) {
   const key = pathKey();
   const paths = [DEPOT_TOOLS_DIR];
 
-  // On apple silicon the default python2 binary does not work
-  // with vpython.  The one depot tools vends _does_ work.  So we
-  // add that one to the path ahead of your default python
-  if (process.platform === 'darwin' && process.arch === 'arm64') {
-    const pythonRelDirFile = path.resolve(DEPOT_TOOLS_DIR, 'python_bin_reldir.txt');
-    if (fs.existsSync(pythonRelDirFile)) {
-      paths.push(path.resolve(DEPOT_TOOLS_DIR, fs.readFileSync(pythonRelDirFile, 'utf8').trim()));
-    }
-  }
   // Remove any duplicates on path so that DEPOT_TOOLS_DIR isn't added if it is already there
   const currentPath = process.env[key].split(path.delimiter);
   opts.env[key] = Array.from(new Set([...paths, ...currentPath])).join(path.delimiter);


### PR DESCRIPTION
This is effectively dead code these days, `python_bin_reldir.txt` doesn't exist now that everything uses Python3 (`python3_bin_reldir.txt` does) so it's never going to succeed with a modern `depot_tools` checkout, and Python3 works fine.