### PR TITLE
test: bump timeout for e-init --root test

### DIFF
--- a/tests/e-init.spec.mjs
+++ b/tests/e-init.spec.mjs
@@ -36,7 +36,7 @@ describe('e-init', () => {
       expect(result.exitCode).toStrictEqual(0);
       expect(fs.statSync(root).isDirectory()).toStrictEqual(true);
       expect(fs.statSync(gclient_file).isFile()).toStrictEqual(true);
-    });
+    }, { timeout: 600_000 });
 
     it('creates a config correctly reflecting options passed', () => {
       const root = path.resolve(sandbox.tmpdir, 'main');


### PR DESCRIPTION
This test loves to timeout in CI on Windows, so give it 10 minutes so it'll stop creating noise. 😬 