### PR TITLE
fix: set `core.longpaths` on Windows by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         git config --global core.eol lf
         git config --global core.filemode false
         git config --global core.fscache true
+        git config --global core.longpaths true
         git config --global core.preloadindex true
         git config --global branch.autosetuprebase always
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # tag: v4.2.2

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -48,6 +48,13 @@ function checkGlobalGitConfig() {
       spawnSyncWithLog('git', ['config', '--global', 'core.preloadindex', 'true']);
     }, new Error('git config --global core.preloadindex should be set to true.'));
   }
+
+  const { stdout: longPaths } = cp.spawnSync('git', ['config', '--global', 'core.longpaths']);
+  if (longPaths.toString().trim() !== 'true') {
+    maybeAutoFix(() => {
+      spawnSyncWithLog('git', ['config', '--global', 'core.longpaths', 'true']);
+    }, new Error('git config --global core.longpaths should be set to true.'));
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
This has hit contributors semi-regularly for years - we should make it default.