### PR TITLE
chore: Revert "chore: update rbe credential helper to 0.5.1 (#734)"

### DIFF
--- a/src/utils/reclient.js
+++ b/src/utils/reclient.js
@@ -14,7 +14,7 @@ const rbeHelperPath = path.resolve(
 );
 const RBE_SERVICE_ADDRESS = 'rbe.notgoma.com:443';
 
-const CREDENTIAL_HELPER_TAG = 'v0.5.1';
+const CREDENTIAL_HELPER_TAG = 'v0.5.0';
 
 let usingRemote = true;
 


### PR DESCRIPTION
This reverts commit e4fae9b3aa083c6d07ad14fff3ed333a094f6d63.

The 0.5.1 release of rbe credential helper is having some issues getting published, so revert that change for now.