### PR TITLE
chore: improve error handling on failed download

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -8,7 +8,21 @@ const { progressStream } = require('./utils/download');
 const write = fs.createWriteStream(process.argv[3]);
 
 async function tryDownload(attemptsLeft = 3) {
-  const response = await fetch(process.argv[2]);
+  const url = process.argv[2];
+  if (!url) {
+    return fatal('No URL provided for download');
+  }
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    if (attemptsLeft === 0) {
+      return fatal(`Download failed - ${response.status} ${response.statusText}`);
+    }
+    console.log(`Download failed - trying ${attemptsLeft} more times`);
+    return tryDownload(attemptsLeft - 1);
+  }
+
   const total = parseInt(response.headers.get('content-length'), 10);
   const progress = progressStream(total, '[:bar] :mbRateMB/s :percent :etas');
 


### PR DESCRIPTION
Ref https://github.com/electron/build-tools/pull/734

The above surfaced some rathe subpar download handling:

```
electron on git:main ❯ e build                                         9:21PM
Downloading "https://dev-cdn-experimental.electronjs.org/reclient/credential-helper/v0.5.1/electron-rbe-credential-helper-darwin-arm64.tar.gz" into /Users/codebytere/.electron_build_tools/third_party/reclient.tar.gz
404 The specified blob does not exist.
/Users/codebytere/.electron_build_tools/node_modules/progress/lib/node-progress.js:160
  complete = Array(Math.max(0, completeLength + 1)).join(this.chars.complete);
             ^

RangeError: Invalid array length
    at ProgressBar.render (/Users/codebytere/.electron_build_tools/node_modules/progress/lib/node-progress.js:160:14)
    at ProgressBar.tick (/Users/codebytere/.electron_build_tools/node_modules/progress/lib/node-progress.js:97:8)
    at PassThrough.<anonymous> (/Users/codebytere/.electron_build_tools/src/utils/download.js:15:11)
    at PassThrough.emit (node:events:536:35)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at node:internal/streams/transform:178:12
    at PassThrough._transform (node:internal/streams/passthrough:46:3)
    at Transform._write (node:internal/streams/transform:171:8)

Node.js v22.13.1
ERROR Failure while downloading reclient
```

After this PR:

```
electron on git:main ❯ e build                                         9:24PM
Downloading "https://dev-cdn-experimental.electronjs.org/reclient/credential-helper/v0.5.1/electron-rbe-credential-helper-darwin-arm64.tar.gz" into /Users/codebytere/.electron_build_tools/third_party/reclient.tar.gz
Download failed - trying 3 more times
Download failed - trying 2 more times
Download failed - trying 1 more times
ERROR Download failed - 404 The specified blob does not exist.
ERROR Failure while downloading reclient
```