### PR TITLE
docs: incorrect argument structure for e:build

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ To see all potential options for this command, run:
 $ e build --help
 ```
 
-Once you have the source, the next step is to build it with `e build [target]`.
+Once you have the source, the next step is to build it with `e build --target [target]`.
 Some of the build targets you may want to build include:
 
 | Target        | Description                                              |


### PR DESCRIPTION
Fix `e build` argument structure.

As explained a few paragraphs down in the README, extra arguments are passed along to ninja, so `e build [target]` results in calling `autoninja [target]  -j 200 electron`, not the expected `autoninja -j 200 [target]`.