### PR TITLE
build: disable remote exec on siso if user doesn't have execute rights

### DIFF
--- a/src/e-build.js
+++ b/src/e-build.js
@@ -60,7 +60,7 @@ function ensureGNGen(config) {
 
 function runNinja(config, target, ninjaArgs) {
   if (reclient.usingRemote && config.remoteBuild !== 'none') {
-    reclient.auth(config);
+    const hasExecute = reclient.auth(config);
 
     // Autoninja sets this absurdly high, we take it down a notch
     if (
@@ -72,7 +72,7 @@ function runNinja(config, target, ninjaArgs) {
     }
 
     if (config.remoteBuild === 'siso') {
-      ninjaArgs.push(...siso.flags(config));
+      ninjaArgs.push(...siso.flags(config, hasExecute));
     }
   } else {
     console.info(`${color.info} Building ${target} with remote execution disabled`);

--- a/src/utils/siso.js
+++ b/src/utils/siso.js
@@ -9,18 +9,22 @@ const SISO_PROJECT = SISO_REAPI_INSTANCE.split('/')[1];
 const sisoEnv = (config) => {
   if (config.remoteBuild !== 'siso') return {};
 
-  return {
+  let sisoEnv = {
     SISO_PROJECT,
     SISO_REAPI_INSTANCE,
     SISO_REAPI_ADDRESS: reclient.serviceAddress(config),
     SISO_CREDENTIAL_HELPER: reclient.helperPath(config),
   };
+
+  const extraFlags = reclient.helperFlags();
+  sisoEnv = Object.assign(sisoEnv, extraFlags);
+  return sisoEnv;
 };
 
-function sisoFlags(config) {
+function sisoFlags(config, hasExecute) {
   if (config.remoteBuild !== 'siso') return [];
 
-  return [
+  const flags = [
     '-remote_jobs',
     200,
     '-project',
@@ -32,6 +36,12 @@ function sisoFlags(config) {
     '-load',
     path.resolve(config.root, 'src/electron/build/siso/main.star'),
   ];
+
+  if (!hasExecute) {
+    flags.push('-re_exec_enable=false');
+  }
+
+  return flags;
 }
 
 async function ensureBackendStarlark(config) {


### PR DESCRIPTION
- Followup to https://github.com/electron/electron/pull/48319.

Unfortunately that change was not sufficient to fix running siso from fork PRS.  This PR updates the rbe-credential-helper to the latest version which sets the environment variable `RBE_exec_strategy` to `local` if the user has read only access to the RBE cluster.  Build tools will then use that environment variable/flag to determine if the user has read only access and if so, build tools will pass the flag `-re_exec_enable=false` to autoninja.  Setting this flag to false disables remote execution but will still allow reading of the RBE cache.  Siso doesn't support setting this flag via an environment variable, so this change is needed in build tools to pass the flag in the autoninja args.