### PR TITLE
fix: paginate commits in e-rcv

### DIFF
--- a/src/e-rcv.js
+++ b/src/e-rcv.js
@@ -274,7 +274,7 @@ program
       'Failed to commit DEPS file change',
     );
 
-    const { data: commits } = await octokit.pulls.listCommits({
+    const commits = await octokit.paginate(octokit.pulls.listCommits, {
       ...ELECTRON_REPO_DATA,
       pull_number: prNumber,
     });


### PR DESCRIPTION
Sometimes roll PRs end up with a lot of commits, the current one has 65 and counting. Use pagination to ensure we get all of the commits.