### PR TITLE
fix: macOS SDK regex on line breaks

### DIFF
--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -105,7 +105,14 @@ function maybeRemoveOldXcodes() {
 // Extract the SDK version from the toolchain file and normalize it.
 function extractSDKVersion(toolchainFile) {
   const contents = fs.readFileSync(toolchainFile, 'utf8');
-  const match = /macOS\s+(?:(\d+(?:\.\d+)?)\s+SDK|SDK\s+(\d+(?:\.\d+)?))/.exec(contents);
+  // Join all comments as single line to allow matching with line breaks
+  const commentsSingleLine = contents
+    .split('\n')
+    .filter((line) => line.startsWith('#'))
+    .map((line) => line.substring(1))
+    .join('');
+  // e.g. macOS 26.0 SDK
+  const match = /macOS\s+(?:(\d+(?:\.\d+)?)\s+SDK|SDK\s+(\d+(?:\.\d+)?))/.exec(commentsSingleLine);
 
   if (match?.[1]) return match[1].includes('.') ? match[1] : `${match[1]}.0`;
   if (match?.[2]) return match[2].includes('.') ? match[2] : `${match[2]}.0`;


### PR DESCRIPTION
https://chromium-review.googlesource.com/c/chromium/src/+/6980166 introduced a line break to the `macOS X.Y SDK` string we're searching for.

```py
# This contains binaries from Xcode 26.0.1 (17A400) along with the macOS 26.0
# SDK (25A352, which is like macOS 26.0 25A354) and the Metal toolchain (17A324,
```

To make our search more robust, I filter for all comments and join them on a single line before matching. This should be backwards compatible with older revisions of `build/mac_toolchain.py`.