### PR TITLE
chore: enable logging by default for `e test`

### DIFF
--- a/src/e-test.js
+++ b/src/e-test.js
@@ -43,6 +43,7 @@ program
     '--no-remote',
     'Build test runner components (e.g. electron:node_headers) without remote execution',
   )
+  .option('--disable-logging', "Don't add the --enable-logging flag for the spec runner")
   .addOption(
     new program.Option(
       '--runners <runner>',
@@ -62,6 +63,9 @@ program
       }
       if (options.electronVersion) {
         specRunnerArgs.push(`--electronVersion=${options.electronVersion}`);
+      }
+      if (!options.disableLogging) {
+        specRunnerArgs.push('--enable-logging');
       }
       let script = './script/spec-runner.js';
       if (options.node) {


### PR DESCRIPTION
Logging is good, let's enable it by default and provide a way to disable it if that's desired.