### PR TITLE
feat: add --commit-updates option to `e patches`

### DIFF
--- a/src/e-patches.js
+++ b/src/e-patches.js
@@ -2,10 +2,11 @@
 
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const program = require('commander');
 
 const evmConfig = require('./evm-config.js');
-const depot = require('./utils/depot-tools');
+const { execFileSync, spawnSync } = require('./utils/depot-tools');
 const { color, fatal } = require('./utils/logging');
 
 program
@@ -19,6 +20,7 @@ program
     path.resolve(evmConfig.current().root, 'src', 'electron', 'patches', 'config.json'),
   )
   .option('--list-targets', 'Show all supported patch targets', false)
+  .option('--commit-updates', 'Automatically commit any non-content changes to patches', false)
   .action((target, options) => {
     try {
       const config = evmConfig.current();
@@ -47,9 +49,24 @@ program
         return;
       }
 
+      // Automatically committing requires a clean working directory to avoid conflicts
+      if (options.commitUpdates) {
+        const gitStatusResult = spawnSync(config, 'git', ['status', '--porcelain'], {
+          cwd: path.resolve(config.root, 'src', 'electron'),
+          stdio: 'pipe',
+          encoding: 'utf8',
+        });
+        if (gitStatusResult.status !== 0 || gitStatusResult.stdout.trim().length !== 0) {
+          console.error(
+            `${color.err} Your current git working directory is not clean, we can't commit patch updates.`,
+          );
+          options.commitUpdates = false;
+        }
+      }
+
       if (target === 'all') {
         const script = path.resolve(srcdir, 'electron', 'script', 'export_all_patches.py');
-        depot.execFileSync(config, 'python3', [script, patchesConfig], {
+        execFileSync(config, 'python3', [script, patchesConfig], {
           cwd: config.root,
           stdio: 'inherit',
           encoding: 'utf8',
@@ -64,7 +81,7 @@ program
         };
         const args = [script, '--output', path.resolve(config.root, targetConfig.patch_dir)];
         if (targetConfig.grep) args.push('--grep', targetConfig.grep);
-        depot.execFileSync(config, 'python3', args, opts);
+        execFileSync(config, 'python3', args, opts);
       } else {
         console.log(`${color.err} Unrecognized target ${color.cmd(target)}.`);
         console.log(
@@ -74,6 +91,69 @@ program
             .join(', ')}`,
         );
         fatal(`See ${color.path(patchesConfig)}`);
+      }
+
+      if (options.commitUpdates) {
+        const spawnOpts = {
+          cwd: path.resolve(config.root, 'src', 'electron'),
+          stdio: 'pipe',
+          encoding: 'utf8',
+        };
+
+        const changedFiles = spawnSync(
+          config,
+          'git',
+          ['diff', '--name-only'],
+          spawnOpts,
+          'Failed to get list of changed files',
+        );
+
+        for (const filename of changedFiles.stdout.trim().split('\n')) {
+          if (!filename.startsWith('patches/')) {
+            console.error(`${color.err} Unexpectedly found non-patch file change: ${filename}`);
+            return;
+          }
+
+          const gitDiff = spawnSync(
+            config,
+            'git',
+            ['diff', filename],
+            spawnOpts,
+            `Failed to get git diff for ${filename}`,
+          );
+          const changedLines = gitDiff.stdout.matchAll(/^[-+].*$/gm);
+
+          let stageFile = true;
+
+          for (const line of changedLines) {
+            // If we find a content-related change, skip this file
+            if (!line[0].match(/^[-+](--|\+\+|index|@@) /)) {
+              console.info(`${color.info} Skipping commit of ${filename} due to content changes.`);
+              stageFile = false;
+              break;
+            }
+          }
+
+          if (stageFile) {
+            spawnSync(
+              config,
+              'git',
+              ['add', filename],
+              spawnOpts,
+              `Failed to stage file ${filename}`,
+            );
+          }
+        }
+
+        const commitMessage = 'chore: update patches';
+
+        spawnSync(
+          config,
+          'git',
+          ['commit', '-m', os.platform() === 'win32' ? `"${commitMessage}"` : commitMessage],
+          spawnOpts,
+          'Failed to commit patch changes',
+        );
       }
     } catch (e) {
       fatal(e);


### PR DESCRIPTION
When doing Chromium rolls, our standard practice is to bundle all non-content changes to patches (i.e. indexes and line number changes) into a single commit with the message "chore: update patches", and then associate content changes with the upstream CL in individual commits. Doing this by hand is a bit tedious and can accidentally mix content changes into the update patches PR, so let's make it an easy automated process when exporting the patches.