### PR TITLE
fix: sign CL cherry-pick commits

### DIFF
--- a/src/e-cherry-pick.js
+++ b/src/e-cherry-pick.js
@@ -137,7 +137,7 @@ program
         d(`Committing changes`);
         const commitMsg = `chore: cherry-pick ${shortCommit} from ${patchDirName}`;
         cp.execSync(`git add ${patchPath}`, { cwd: electronPath });
-        cp.execSync(`git commit -m "${commitMsg}"`, {
+        cp.execSync(`git commit -S -m "${commitMsg}"`, {
           cwd: electronPath,
           stdio: 'ignore',
         });


### PR DESCRIPTION
For me, the `git push` failed due to:

```
remote: - Commits must have verified signatures.
remote:   Found 1 violation:
```