### PR TITLE
fix: gate Electron's extra Win SDK siso headers on target OS, not host

### DIFF
--- a/tools/main.star
+++ b/tools/main.star
@@ -39,18 +39,21 @@ def init(ctx):
           "clang_large": step_config["platforms"]["default"],          
       })      
 
-    if runtime.os == "windows":
-      # Add additional Windows SDK headers needed by Electron      
+    # Add additional Windows SDK headers needed by Electron. Use
+    # win_sdk.enabled() (target_os == "win") rather than runtime.os so this
+    # also applies when cross-compiling Windows on a Linux host.
+    if win_sdk.enabled(ctx):
       win_toolchain_dir = win_sdk.toolchain_dir(ctx)
-      if win_toolchain_dir:
-        sdk_version = gn_logs.read(ctx).get("windows_sdk_version")
+      sdk_version = gn_logs.read(ctx).get("windows_sdk_version")
+      if win_toolchain_dir and sdk_version and (win_toolchain_dir + ":headers") in step_config["input_deps"]:
         step_config["input_deps"][win_toolchain_dir + ":headers"].extend([
           # third_party/electron_node/deps/uv/include/uv/win.h includes mswsock.h
           path.join(win_toolchain_dir, "Windows Kits/10/Include", sdk_version, "um/mswsock.h"),
           # third_party/electron_node/src/debug_utils.cc includes lm.h
-          path.join(win_toolchain_dir, "Windows Kits/10/Include", sdk_version, "um/Lm.h"),          
+          path.join(win_toolchain_dir, "Windows Kits/10/Include", sdk_version, "um/Lm.h"),
         ])
-      
+
+    if runtime.os == "windows":
       # Update platforms to match our default siso config instead of reclient configs.
       step_config["platforms"].update({
           "clang-cl": step_config["platforms"]["default"],


### PR DESCRIPTION
The `mswsock.h` / `Lm.h` additions to the win_toolchain `:headers` input set were guarded by `if runtime.os == "windows"`. When cross-compiling Windows on a Linux host (`target_os=win`, host=linux), that block is skipped, so siso never uploads those headers to the RBE worker and libuv's `win/tty.c` (and friends) fail with `'mswsock.h' file not found`.

Use `win_sdk.enabled(ctx)` instead, which checks `target_os == "win"` — the same predicate Chromium's own `build/config/siso/win_sdk.star` uses to populate `:headers` in the first place. Also guard on `sdk_version` and the `:headers` key actually being present so this is a no-op when the upstream config didn't set them up (e.g. before `gn_logs.txt` exists on a clean build).

Needed for electron/electron#50796 (Windows cross-compile on Linux), which currently carries an in-repo copy of this file and can drop it once this lands.