### PR TITLE
refactor: run ensurePrereqs for all e commands

### DIFF
--- a/src/e-sync.ts
+++ b/src/e-sync.ts
@@ -11,7 +11,6 @@ import { ensureDir } from './utils/paths.js';
 import * as depot from './utils/depot-tools.js';
 import { configureReclient } from './utils/setup-reclient-chromium.js';
 import { ensureSDK } from './utils/sdk.js';
-import { ensurePrereqs } from './utils/prereqs.js';
 import type { ElectronRemotes } from './types.js';
 
 function setRemotes(cwd: string, repo: ElectronRemotes): void {
@@ -49,8 +48,6 @@ function setRemotes(cwd: string, repo: ElectronRemotes): void {
 }
 
 function runGClientSync(syncArgs: string[], syncOpts: { threeWay?: boolean }): void {
-  ensurePrereqs();
-
   const config = evmConfig.current();
   const srcdir = path.resolve(config.root, 'src');
   ensureDir(srcdir);

--- a/src/e.ts
+++ b/src/e.ts
@@ -9,11 +9,15 @@ import { program } from 'commander';
 import * as evmConfig from './evm-config.js';
 import { color, fatal } from './utils/logging.js';
 import * as depot from './utils/depot-tools.js';
+import { ensurePrereqs } from './utils/prereqs.js';
 import { refreshPathVariable } from './utils/refresh-path.js';
 import { ensureSDK } from './utils/sdk.js';
 
 // Refresh the PATH variable at the top of this shell so that retries in the same shell get the latest PATH variable
 refreshPathVariable();
+
+// Fail fast on unsupported Node.js / Python runtimes before doing any work.
+ensurePrereqs();
 
 function maybeCheckForUpdates(): void {
   // skip auto-update check if disabled


### PR DESCRIPTION
The Node.js 22 and Python 3.9 runtime checks in ensurePrereqs() were only invoked from e-sync, so users on unsupported runtimes got a clear error on `e sync` but silent or confusing failures from `e build`, `e patches`, `e test`, and friends.

Move the call into the top-level dispatcher in src/e.ts so every subcommand is covered by a single call site, and drop the now-redundant invocation from e-sync.ts.