### PR TITLE
feat: set poison_history_size in asan builds

### DIFF
--- a/src/e-init.ts
+++ b/src/e-init.ts
@@ -81,6 +81,16 @@ function createConfig(options: InitOptions): EvmConfig {
   };
 
   const gitCachePath = process.env['GIT_CACHE_PATH'];
+  const gen = {
+    args: gn_args,
+    out: options.out ?? 'Testing',
+  };
+  const env = {
+    CHROMIUM_BUILDTOOLS_PATH: path.resolve(root, 'src', 'buildtools'),
+    GIT_CACHE_PATH: gitCachePath ? resolvePath(gitCachePath) : path.resolve(homedir, '.git_cache'),
+  };
+
+  evmConfig.ensureAsanOptions({ gen, env });
 
   return {
     $schema: pathToFileURL(path.resolve(import.meta.dirname, '..', 'evm-config.schema.json')).href,
@@ -89,17 +99,9 @@ function createConfig(options: InitOptions): EvmConfig {
     remotes: {
       electron,
     },
-    gen: {
-      args: gn_args,
-      out: options.out ?? 'Testing',
-    },
+    gen,
     preserveSDK: 5,
-    env: {
-      CHROMIUM_BUILDTOOLS_PATH: path.resolve(root, 'src', 'buildtools'),
-      GIT_CACHE_PATH: gitCachePath
-        ? resolvePath(gitCachePath)
-        : path.resolve(homedir, '.git_cache'),
-    },
+    env,
   };
 }
 

--- a/src/evm-config.ts
+++ b/src/evm-config.ts
@@ -15,8 +15,59 @@ const configRoot = (): string =>
 
 let shouldWarn = true;
 
+type AsanOptions = Record<string, string | number>;
+
+export const defaultAsanOptions: AsanOptions = {
+  poison_history_size: 16,
+};
+
+// 'key1=val1:key2=val2' => { key1: val1, key2: val2 }
+function parseAsanOptions(value?: string): AsanOptions {
+  return Object.fromEntries(
+    (value ?? '')
+      .split(':')
+      .filter(Boolean)
+      .map((entry) => entry.split('=', 2))
+      .map(([key, optionValue = '1']) => [key, optionValue])
+      .filter(([key]) => Boolean(key)),
+  );
+}
+
+// { key1: val1, key2: val2 } ==> 'key1=val1:key2=val2'
+function stringifyAsanOptions(options: AsanOptions): string {
+  return Object.entries(options)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(':');
+}
+
+function ensureConfigEnv<T extends Pick<EvmConfig, 'env'>>(
+  config: T,
+): asserts config is T & { env: NonNullable<EvmConfig['env']> } {
+  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+}
+
 export function resetShouldWarn(): void {
   shouldWarn = true;
+}
+
+export function ensureAsanOptions(
+  config: Pick<EvmConfig, 'gen' | 'env'>,
+  changes?: string[],
+): void {
+  const hasAsanGN = Boolean(config.gen?.args?.find((arg) => /^is_asan ?= ?true$/.test(arg)));
+  if (!hasAsanGN) return;
+
+  ensureConfigEnv(config);
+
+  const asanOptions = parseAsanOptions(config.env['ASAN_OPTIONS']);
+  if ('poison_history_size' in asanOptions) return;
+
+  config.env['ASAN_OPTIONS'] = stringifyAsanOptions({
+    ...defaultAsanOptions,
+    ...asanOptions,
+  });
+
+  changes?.push(`added ${color.config('ASAN_OPTIONS')} for improved ASan poisoning traces`);
 }
 
 // If you want your shell sessions to each have different active configs,
@@ -188,7 +239,7 @@ export function validateConfig(config: EvmConfig): ValidationError[] | undefined
 export function setEnvVar(name: string, key: string, value: string): void {
   const config = loadConfigFileRaw(name);
 
-  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+  ensureConfigEnv(config);
   config.env[key] = value;
 
   save(name, config);
@@ -288,7 +339,8 @@ export function sanitizeConfig(
     delete config.reclientServiceAddress;
   }
 
-  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+  ensureConfigEnv(config);
+  ensureAsanOptions(config, changes);
 
   if (!config.env.CHROMIUM_BUILDTOOLS_PATH && config.root) {
     const toolsPath = path.resolve(config.root, 'src', 'buildtools');

--- a/tests/e-init.spec.mjs
+++ b/tests/e-init.spec.mjs
@@ -77,6 +77,25 @@ describe('e-init', () => {
       expect(validationErrors).toBeFalsy();
     });
 
+    it('adds ASAN poison history settings for asan configs', () => {
+      const root = path.resolve(sandbox.tmpdir, 'asan-root');
+
+      const result = sandbox
+        .eInitRunner()
+        .name('asan-build')
+        .root(root)
+        .asan()
+        .run();
+
+      expect(result.exitCode).toStrictEqual(0);
+
+      const configPath = path.resolve(sandbox.tmpdir, 'evm-config', 'evm.asan-build.json');
+      const config = require(configPath);
+
+      expect(config.gen.args).toContain('is_asan=true');
+      expect(config.env.ASAN_OPTIONS).toMatch(/poison_history_size=\d+/);
+    });
+
     it('logs an info message when the new build config root already has a .gclient file', () => {
       const root = path.resolve(sandbox.tmpdir, 'main');
 

--- a/tests/evm-config.spec.mjs
+++ b/tests/evm-config.spec.mjs
@@ -98,6 +98,35 @@ describe('configValidationLevel', () => {
     spy.mockClear();
   });
 
+  it('should add ASAN poison history settings for asan configs', () => {
+    const config = sanitizeConfig('foobar', {
+      ...validConfig,
+      gen: {
+        ...validConfig.gen,
+        args: ['is_asan=true'],
+      },
+    });
+
+    expect(config.env.ASAN_OPTIONS).toMatch(/poison_history_size=\d+/);
+  });
+
+  it('should preserve an existing ASAN poison history setting', () => {
+    const config = sanitizeConfig('foobar', {
+      ...validConfig,
+      gen: {
+        ...validConfig.gen,
+        args: ['is_asan=true'],
+      },
+      env: {
+        ...validConfig.env,
+        ASAN_OPTIONS: 'detect_leaks=0:poison_history_size=42',
+      },
+    });
+
+    expect(config.env.ASAN_OPTIONS).toMatch(/detect_leaks=0/);
+    expect(config.env.ASAN_OPTIONS).toMatch(/poison_history_size=42/);
+  });
+
   it('should log warnings for invalid config if set to warn', () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});


### PR DESCRIPTION
In asan builds, set the `poison_history_size` variable.

Related: https://github.com/electron/electron/pull/51069#issuecomment-4255094814

https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/+/ab03e5189c2071c21fe8226e0b531f698701f476%5E%21/