### PR TITLE
feat: `e env <command> [args...]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,20 @@ $ e shell
 # Running "/bin/zsh"
 ```
 
+### `e env <command> [args...]`
+
+`e env` runs any command with the active build-tools environment variables applied.
+
+This is useful for using build-tools' configuration for command-line Electron scripts
+that require `CHROMIUM_BULDTOOLS_PATH` to be set and for `PATH` to include depot_tools,
+such as `git commit` and `yarn run lint`.
+
+```sh
+$ e env git commit
+$ e env yarn run lint
+$ e env mycommand.sh arg1 arg2
+```
+
 ### `e backport <PR>`
 
 `e backport <PR>` assists with manual backport processes on the specified pull request.

--- a/src/_e
+++ b/src/_e
@@ -23,7 +23,7 @@ _e () {
   local line
 
   _arguments -C \
-    "1: :(build debug help init make new node patches pr run show start sync test use)"
+    "1: :(build debug env help init make new node patches pr run show start sync test use)"\
     "*::arg:->args"
 
   local completion_func="_e__${line[1]}"

--- a/src/e.ts
+++ b/src/e.ts
@@ -2,6 +2,7 @@
 
 import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { program } from 'commander';
@@ -218,6 +219,35 @@ program
     } catch (e) {
       fatal(e);
     }
+  });
+
+program
+  .command('env')
+  .description('Run a command with the active build-tools environment')
+  .allowUnknownOption()
+  .helpOption('\0')
+  .action(() => {
+    const args = process.argv.slice(3);
+    if (args[0] === '--') args.shift();
+    const cmd = args[0];
+    if (!cmd) fatal(`Must provide a command to 'e env'`);
+
+    const { status, error } = depot.spawnSync(evmConfig.current(), cmd, args.slice(1), {
+      stdio: 'inherit',
+      shell: os.platform() === 'win32',
+    });
+
+    if (error) fatal(`Failed to run command:\n ${error}`, status ?? 1);
+
+    process.exit(status ?? 0);
+  })
+  .on('--help', () => {
+    console.log('');
+    console.log('Examples:');
+    console.log('');
+    console.log('  $ e env git commit');
+    console.log('  $ e env yarn run lint:cpp');
+    console.log('  $ e env mycommand.sh arg1 arg2');
   });
 
 program

--- a/tests/e-env.spec.mjs
+++ b/tests/e-env.spec.mjs
@@ -1,0 +1,78 @@
+import path from 'path';
+import { pathKey } from '../dist/utils/path-key.js';
+import createSandbox from './sandbox';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('e-env', () => {
+  let sandbox;
+  let root;
+  let name;
+  let out;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    root = path.join(sandbox.tmpdir, sandbox.randomString());
+    name = sandbox.randomString();
+    out = sandbox.randomString();
+  });
+
+  afterEach(() => {
+    sandbox.cleanup();
+  });
+
+  it('fails clearly if no command is provided', () => {
+    const result = sandbox
+      .eRunner()
+      .args('env')
+      .run();
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/must provide a command to 'e env'/i);
+  });
+
+  it('forwards child arguments and exposes the active build environment', () => {
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(name)
+      .out(out)
+      .run();
+
+    const result = sandbox
+      .eRunner()
+      .args(
+        'env',
+        'node',
+        '-e',
+        `console.log(JSON.stringify({ argv: process.argv.slice(1), hasBuildtoolsPath: !!process.env.CHROMIUM_BUILDTOOLS_PATH, hasGitCachePath: !!process.env.GIT_CACHE_PATH, hasPath: !!process.env[${JSON.stringify(pathKey())}] }))`,
+        'arg1',
+        '--child-flag',
+      )
+      .run();
+
+    expect(result.exitCode).toBe(0);
+    const lines = result.stdout.split('\n').filter(Boolean);
+    const payload = JSON.parse(lines[lines.length - 1]);
+    expect(payload.argv).toEqual(['arg1', '--child-flag']);
+    expect(payload.hasBuildtoolsPath).toBe(true);
+    expect(payload.hasGitCachePath).toBe(true);
+    expect(payload.hasPath).toBe(true);
+  });
+
+  it('returns the child command status code', () => {
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(name)
+      .out(out)
+      .run();
+
+    const result = sandbox
+      .eRunner()
+      .args('env', 'node', '-e', 'process.exit(7)')
+      .run();
+
+    expect(result.exitCode).toBe(7);
+  });
+});

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -201,6 +201,27 @@ function eSyncRunner(execOptions) {
   return o;
 }
 
+// A top-level `e` helper.
+// Example use: result = eRunner().args('env', 'node', '--version').run();
+// Returns { exitCode:number, stderr:string, stdout:string }
+function eRunner(execOptions) {
+  const stdio = 'pipe';
+  const cmd = path.resolve(buildToolsDistDir, 'e.js');
+  const args = [];
+
+  const o = {
+    args: (...vals) => {
+      args.push(...vals);
+      return o;
+    },
+    run: () => {
+      return runSync([cmd, ...args], { ...execOptions, stdio });
+    },
+  };
+
+  return o;
+}
+
 // An `e remove` helper.
 // Example use: result = eRemoveRunner().name('test').run();
 // Returns { exitCode:number, stderr:string, stdout:string }
@@ -261,6 +282,9 @@ function createSandbox() {
     },
     eSyncRunner: () => {
       return eSyncRunner(execOptions);
+    },
+    eRunner: () => {
+      return eRunner(execOptions);
     },
     eRemoveRunner: () => {
       return eRemoveRunner(execOptions);


### PR DESCRIPTION
`$ e env <command> [args...]` runs any command with build-tools' environment variables set.

This is useful if you wan to use build-tools' env for command-line Electron scripts that require `CHROMIUM_BULDTOOLS_PATH` to be set and for `PATH` to include depot_tools, such as `git commit` and `yarn run lint`.

Related: https://github.com/electron/electron/pull/50858

Related: https://github.com/electron/electron/pull/51034