### PR TITLE
feat: add `--config=<name>` to override active config for one invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ have multiple build configurations and manage them in a way similar to nvm:
 | nvm current          | e show current     | Show which configuration is currently in use   |
 | nvm use &lt;name&gt; | e use &lt;name&gt; | Change which configuration is currently in use |
 
+To run a single command against a config other than the current one without
+switching, pass `--config=<name>` as the first argument:
+
+```sh
+$ e --config=my-release build
+$ e --config=main-debug show root
+```
+
 Getting the source code is a lot more than cloning `electron/electron`.
 Electron is built on top of Chromium (with Electron patches) and Node
 (with more Electron patches). A source tree needs to have all of the

--- a/src/e.ts
+++ b/src/e.ts
@@ -78,7 +78,27 @@ function maybeCheckForUpdates(): void {
 maybeCheckForUpdates();
 evmConfig.resetShouldWarn();
 
-program.description('Electron build tool').usage('<command> [commandArgs...]');
+// Allow `e --config=<name> <command>` to override the active build config for
+// this invocation only. Commander's executable subcommands run in child
+// processes, so the override is passed via EVM_CURRENT which evm-config reads.
+{
+  const first = process.argv[2];
+  let override: string | undefined;
+  if (first?.startsWith('--config=')) {
+    override = first.slice('--config='.length);
+    process.argv.splice(2, 1);
+  } else if (first === '--config') {
+    override = process.argv[3];
+    process.argv.splice(2, 2);
+  }
+  if (override) {
+    process.env['EVM_CURRENT'] = override;
+  } else if (override === '') {
+    fatal(`${color.cmd('--config')} requires a build config name`);
+  }
+}
+
+program.description('Electron build tool').usage('[--config=<name>] <command> [commandArgs...]');
 
 program
   .command('init [options] <name>', 'Create a new build config')

--- a/src/evm-config.ts
+++ b/src/evm-config.ts
@@ -112,6 +112,10 @@ export function names(): string[] {
 }
 
 function getCurrentFileName(): string | null {
+  // One-off override from `e --config=<name> ...`.
+  const override = process.env['EVM_CURRENT'];
+  if (override) return override;
+
   return currentFiles().reduce<string | null>((name, filename) => {
     try {
       // `||` (not `??`) is deliberate: an empty file — e.g. the fresh

--- a/tests/e-show.spec.mjs
+++ b/tests/e-show.spec.mjs
@@ -99,6 +99,47 @@ describe('e-show', () => {
     expect(result.stdout).toEqual(path.resolve(root, 'src', srcdir));
   });
 
+  it('honors --config=<name> for a single invocation', () => {
+    const otherRoot = path.join(sandbox.tmpdir, sandbox.randomString());
+    const otherName = sandbox.randomString();
+    sandbox
+      .eInitRunner()
+      .root(otherRoot)
+      .name(otherName)
+      .run();
+    sandbox
+      .eInitRunner()
+      .root(root)
+      .name(name)
+      .run();
+
+    // Active config is `name`.
+    expect(
+      sandbox
+        .eShowRunner()
+        .current()
+        .run().stdout,
+    ).toEqual(name);
+
+    // `--config` overrides it for this call only (both = and space forms).
+    for (const flagArgs of [[`--config=${otherName}`], ['--config', otherName]]) {
+      const result = sandbox
+        .eRunner()
+        .args(...flagArgs, 'show', 'current')
+        .run();
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toEqual(otherName);
+    }
+
+    // Persistent current is untouched afterwards.
+    expect(
+      sandbox
+        .eShowRunner()
+        .current()
+        .run().stdout,
+    ).toEqual(name);
+  });
+
   it('shows all configs', () => {
     sandbox
       .eInitRunner()

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -201,6 +201,27 @@ function eSyncRunner(execOptions) {
   return o;
 }
 
+// A generic `e` helper that invokes the top-level dispatcher with raw args.
+// Example use: result = eRunner().args('--config=foo', 'show', 'current').run();
+// Returns { exitCode:number, stderr:string, stdout:string }
+function eRunner(execOptions) {
+  const stdio = 'pipe';
+  const cmd = path.resolve(buildToolsDistDir, 'e.js');
+  let args = [];
+
+  const o = {
+    args: (...a) => {
+      args = a;
+      return o;
+    },
+    run: () => {
+      return runSync([cmd, ...args], { ...execOptions, stdio });
+    },
+  };
+
+  return o;
+}
+
 // An `e remove` helper.
 // Example use: result = eRemoveRunner().name('test').run();
 // Returns { exitCode:number, stderr:string, stdout:string }
@@ -264,6 +285,9 @@ function createSandbox() {
     },
     eRemoveRunner: () => {
       return eRemoveRunner(execOptions);
+    },
+    eRunner: () => {
+      return eRunner(execOptions);
     },
     randomString: () => Math.random().toString(36).substring(2, 15),
     tmpdir,


### PR DESCRIPTION
Adds a top-level `--config=<name>` flag so any `e` command can be run against a specific build config without changing the active one (no `e use <a>` / `e use <b>` dance).

```sh
e --config=my-release build
e --config=main-debug show root
```

#### How

`e.ts` intercepts `--config` (first arg only, `=` or space form), strips it from argv, and exports `EVM_CURRENT`. `evm-config.ts`'s `getCurrentFileName()` checks that env var before reading `evm-current.txt`. Because Commander spawns executable subcommands as child processes that inherit env, the override reaches every command with no per-subcommand changes.

#### Tests

- [x] New `e-show` spec: two configs, verifies `--config` overrides for one call and leaves persistent current untouched (both `=` and space forms)
- [x] `yarn build` / `yarn lint` / `yarn test` (64/64)