### PR TITLE
feat: add option to skip gn gen

### DIFF
--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -48,8 +48,27 @@ async function runGNGen(config: SanitizedConfig): Promise<void> {
   await depot.spawn(config, gnPath, execArgs, execOpts);
 }
 
-async function ensureGNGen(config: SanitizedConfig): Promise<void> {
+type GenMode = 'skip' | 'include' | 'only';
+
+async function ensureGNGen(config: SanitizedConfig, genMode: GenMode): Promise<void> {
   const buildfile = path.resolve(evmConfig.outDir(config), 'build.ninja');
+
+  if (genMode === 'only') {
+    return runGNGen(config);
+  }
+
+  if (genMode === 'skip') {
+    if (!fs.existsSync(buildfile)) {
+      fatal(
+        `Cannot skip \`gn gen\` because ${color.path(buildfile)} does not exist. Run ${color.cmd(
+          'e build',
+        )} with ${color.cmd('--gen include')} or ${color.cmd('--gen only')} first.`,
+      );
+    }
+    console.info(`${color.info} Reusing existing generated build files in ${color.path(buildfile)}`);
+    return;
+  }
+
   if (!fs.existsSync(buildfile)) return runGNGen(config);
   const argsFile = path.resolve(evmConfig.outDir(config), 'args.gn');
   if (!fs.existsSync(argsFile)) return runGNGen(config);
@@ -64,6 +83,7 @@ async function runNinja(
   config: SanitizedConfig,
   target: string,
   ninjaArgs: string[],
+  genMode: GenMode,
 ): Promise<number> {
   if (reclient.usingRemote && config.remoteBuild !== 'none') {
     const hasExecute = reclient.auth(config);
@@ -85,7 +105,7 @@ async function runNinja(
   }
 
   depot.ensure();
-  await ensureGNGen(config);
+  await ensureGNGen(config, genMode);
 
   // Using remoteexec means that we need autoninja so that reproxy is started + stopped
   // correctly
@@ -104,7 +124,9 @@ async function runNinja(
 }
 
 interface BuildOptions {
+  gen: GenMode;
   onlyGen: boolean;
+  skipGnGen: boolean;
   target?: string;
   remote: boolean;
 }
@@ -112,7 +134,9 @@ interface BuildOptions {
 program
   .arguments('[ninjaArgs...]')
   .description('Build Electron and other targets.')
-  .option('--only-gen', 'Only run `gn gen`', false)
+  .option('--gen <mode>', 'Control when to run `gn gen`: include (default), skip, or only', 'include')
+  .option('--only-gen', 'Alias for `--gen only`', false)
+  .option('--skip-gn-gen', 'Alias for `--gen skip`', false)
   .option('-t|--target [target]', 'Build a specific ninja target')
   .option('--no-remote', 'Build without remote execution (entirely locally)')
   .allowUnknownOption()
@@ -138,13 +162,33 @@ program
         ensureSDK();
       }
 
-      if (options.onlyGen) {
+      const genMode = (() => {
+        const fromOption = options.gen as GenMode;
+        if (!['skip', 'include', 'only'].includes(fromOption)) {
+          fatal(
+            `Invalid value for ${color.cmd('--gen')}: ${fromOption}. Expected one of skip, include, or only.`,
+          );
+        }
+
+        if (options.onlyGen && fromOption === 'skip') {
+          fatal(`Cannot combine ${color.cmd('--only-gen')} with ${color.cmd('--gen skip')}`);
+        }
+        if (options.skipGnGen && fromOption === 'only') {
+          fatal(`Cannot combine ${color.cmd('--skip-gn-gen')} with ${color.cmd('--gen only')}`);
+        }
+
+        if (options.onlyGen) return 'only';
+        if (options.skipGnGen) return 'skip';
+        return fromOption;
+      })();
+
+      if (genMode === 'only') {
         await runGNGen(config);
         return;
       }
 
       const buildTarget = options.target ?? evmConfig.getDefaultTarget();
-      const exitCode = await runNinja(config, buildTarget, ninjaArgs);
+      const exitCode = await runNinja(config, buildTarget, ninjaArgs, genMode);
       process.exit(exitCode);
     } catch (e) {
       fatal(e);

--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -65,7 +65,9 @@ async function ensureGNGen(config: SanitizedConfig, genMode: GenMode): Promise<v
         )} with ${color.cmd('--gen include')} or ${color.cmd('--gen only')} first.`,
       );
     }
-    console.info(`${color.info} Reusing existing generated build files in ${color.path(buildfile)}`);
+    console.info(
+      `${color.info} Reusing existing generated build files in ${color.path(buildfile)}`,
+    );
     return;
   }
 
@@ -134,7 +136,11 @@ interface BuildOptions {
 program
   .arguments('[ninjaArgs...]')
   .description('Build Electron and other targets.')
-  .option('--gen <mode>', 'Control when to run `gn gen`: include (default), skip, or only', 'include')
+  .option(
+    '--gen <mode>',
+    'Control when to run `gn gen`: include (default), skip, or only',
+    'include',
+  )
   .option('--only-gen', 'Alias for `--gen only`', false)
   .option('--skip-gn-gen', 'Alias for `--gen skip`', false)
   .option('-t|--target [target]', 'Build a specific ninja target')

--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -53,20 +53,13 @@ type GenMode = 'on' | 'off' | 'only';
 async function ensureGNGen(config: SanitizedConfig, genMode: GenMode): Promise<void> {
   const buildfile = path.resolve(evmConfig.outDir(config), 'build.ninja');
 
-  if (genMode === 'only') {
-    return runGNGen(config);
-  }
+  if (genMode === 'only') return runGNGen(config);
 
   if (genMode === 'off') {
-    if (!fs.existsSync(buildfile)) {
-      fatal(
-        `Cannot skip \`gn gen\` because ${color.path(buildfile)} does not exist. Run ${color.cmd(
-          'e build',
-        )} with ${color.cmd('--gen on')} or ${color.cmd('--gen only')} first.`,
-      );
-    }
+    if (!fs.existsSync(buildfile))
+      fatal(`Cannot skip \`gn gen\` because ${color.path(buildfile)} does not exist.`);
     console.info(
-      `${color.info} Reusing existing generated build files in ${color.path(buildfile)}`,
+      `${color.info} Using pre-existing generated build files in ${color.path(buildfile)}`,
     );
     return;
   }
@@ -136,11 +129,7 @@ interface BuildOptions {
 program
   .arguments('[ninjaArgs...]')
   .description('Build Electron and other targets.')
-  .option(
-    '--gen <mode>',
-    'Control when to run `gn gen`: on (default), off, or only',
-    'on',
-  )
+  .option('--gen <mode>', 'Control when to run `gn gen`: on (default), off, or only', 'on')
   .option('--only-gen', 'Alias for `--gen only`', false)
   .option('--skip-gn-gen', 'Alias for `--gen off`', false)
   .option('-t|--target [target]', 'Build a specific ninja target')

--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -118,7 +118,6 @@ async function runNinja(
 
 interface BuildOptions {
   gen: GenMode;
-  onlyGen: boolean;
   target?: string;
   remote: boolean;
 }
@@ -127,7 +126,6 @@ program
   .arguments('[ninjaArgs...]')
   .description('Build Electron and other targets.')
   .option('--gen <mode>', 'Control when to run `gn gen`: on (default), off, or only', 'on')
-  .option('--only-gen', 'Alias for `--gen only`', false)
   .option('-t|--target [target]', 'Build a specific ninja target')
   .option('--no-remote', 'Build without remote execution (entirely locally)')
   .allowUnknownOption()
@@ -157,9 +155,7 @@ program
         const fromOption = options.gen as GenMode;
         if (!['off', 'on', 'only'].includes(fromOption))
           fatal(`Invalid ${color.cmd('--gen')} value. Expected 'on', 'off', or 'only'.`);
-        if (options.onlyGen && fromOption !== 'only')
-          fatal(`Cannot combine ${color.cmd('--only-gen')} with ${color.cmd('--gen')}`);
-        return options.onlyGen ? 'only' : fromOption;
+        return fromOption;
       })();
 
       if (genMode === 'only') {

--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -48,7 +48,7 @@ async function runGNGen(config: SanitizedConfig): Promise<void> {
   await depot.spawn(config, gnPath, execArgs, execOpts);
 }
 
-type GenMode = 'skip' | 'include' | 'only';
+type GenMode = 'on' | 'off' | 'only';
 
 async function ensureGNGen(config: SanitizedConfig, genMode: GenMode): Promise<void> {
   const buildfile = path.resolve(evmConfig.outDir(config), 'build.ninja');
@@ -57,12 +57,12 @@ async function ensureGNGen(config: SanitizedConfig, genMode: GenMode): Promise<v
     return runGNGen(config);
   }
 
-  if (genMode === 'skip') {
+  if (genMode === 'off') {
     if (!fs.existsSync(buildfile)) {
       fatal(
         `Cannot skip \`gn gen\` because ${color.path(buildfile)} does not exist. Run ${color.cmd(
           'e build',
-        )} with ${color.cmd('--gen include')} or ${color.cmd('--gen only')} first.`,
+        )} with ${color.cmd('--gen on')} or ${color.cmd('--gen only')} first.`,
       );
     }
     console.info(
@@ -138,11 +138,11 @@ program
   .description('Build Electron and other targets.')
   .option(
     '--gen <mode>',
-    'Control when to run `gn gen`: include (default), skip, or only',
-    'include',
+    'Control when to run `gn gen`: on (default), off, or only',
+    'on',
   )
   .option('--only-gen', 'Alias for `--gen only`', false)
-  .option('--skip-gn-gen', 'Alias for `--gen skip`', false)
+  .option('--skip-gn-gen', 'Alias for `--gen off`', false)
   .option('-t|--target [target]', 'Build a specific ninja target')
   .option('--no-remote', 'Build without remote execution (entirely locally)')
   .allowUnknownOption()
@@ -170,21 +170,21 @@ program
 
       const genMode = (() => {
         const fromOption = options.gen as GenMode;
-        if (!['skip', 'include', 'only'].includes(fromOption)) {
+        if (!['off', 'on', 'only'].includes(fromOption)) {
           fatal(
-            `Invalid value for ${color.cmd('--gen')}: ${fromOption}. Expected one of skip, include, or only.`,
+            `Invalid value for ${color.cmd('--gen')}: ${fromOption}. Expected one of on, off, or only.`,
           );
         }
 
-        if (options.onlyGen && fromOption === 'skip') {
-          fatal(`Cannot combine ${color.cmd('--only-gen')} with ${color.cmd('--gen skip')}`);
+        if (options.onlyGen && fromOption === 'off') {
+          fatal(`Cannot combine ${color.cmd('--only-gen')} with ${color.cmd('--gen off')}`);
         }
         if (options.skipGnGen && fromOption === 'only') {
           fatal(`Cannot combine ${color.cmd('--skip-gn-gen')} with ${color.cmd('--gen only')}`);
         }
 
         if (options.onlyGen) return 'only';
-        if (options.skipGnGen) return 'skip';
+        if (options.skipGnGen) return 'off';
         return fromOption;
       })();
 

--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -58,9 +58,7 @@ async function ensureGNGen(config: SanitizedConfig, genMode: GenMode): Promise<v
   if (genMode === 'off') {
     if (!fs.existsSync(buildfile))
       fatal(`Cannot skip \`gn gen\` because ${color.path(buildfile)} does not exist.`);
-    console.info(
-      `${color.info} Using pre-existing generated build files in ${color.path(buildfile)}`,
-    );
+    console.info(`${color.info} Using pre-existing build files in ${color.path(buildfile)}`);
     return;
   }
 
@@ -121,7 +119,6 @@ async function runNinja(
 interface BuildOptions {
   gen: GenMode;
   onlyGen: boolean;
-  skipGnGen: boolean;
   target?: string;
   remote: boolean;
 }
@@ -131,7 +128,6 @@ program
   .description('Build Electron and other targets.')
   .option('--gen <mode>', 'Control when to run `gn gen`: on (default), off, or only', 'on')
   .option('--only-gen', 'Alias for `--gen only`', false)
-  .option('--skip-gn-gen', 'Alias for `--gen off`', false)
   .option('-t|--target [target]', 'Build a specific ninja target')
   .option('--no-remote', 'Build without remote execution (entirely locally)')
   .allowUnknownOption()
@@ -159,22 +155,11 @@ program
 
       const genMode = (() => {
         const fromOption = options.gen as GenMode;
-        if (!['off', 'on', 'only'].includes(fromOption)) {
-          fatal(
-            `Invalid value for ${color.cmd('--gen')}: ${fromOption}. Expected one of on, off, or only.`,
-          );
-        }
-
-        if (options.onlyGen && fromOption === 'off') {
-          fatal(`Cannot combine ${color.cmd('--only-gen')} with ${color.cmd('--gen off')}`);
-        }
-        if (options.skipGnGen && fromOption === 'only') {
-          fatal(`Cannot combine ${color.cmd('--skip-gn-gen')} with ${color.cmd('--gen only')}`);
-        }
-
-        if (options.onlyGen) return 'only';
-        if (options.skipGnGen) return 'off';
-        return fromOption;
+        if (!['off', 'on', 'only'].includes(fromOption))
+          fatal(`Invalid ${color.cmd('--gen')} value. Expected 'on', 'off', or 'only'.`);
+        if (options.onlyGen && fromOption !== 'only')
+          fatal(`Cannot combine ${color.cmd('--only-gen')} with ${color.cmd('--gen')}`);
+        return options.onlyGen ? 'only' : fromOption;
       })();
 
       if (genMode === 'only') {


### PR DESCRIPTION
Add an option to skip `gn gen` when running `e build`.

Rationale: I have a downstream fork of Electron that has a couple of different build configuration and doesn't fit cleanly into e/e's upstream model.  So it has its own script for running `gn gen` with the local setup.

For the most part, I'd like to be using build-tools.  But `e build` unconditionally runs `gn gen`, so it clobbers my downstream build filles. This PR adds an opt-in cli arg for build-tools to skip `gn gen`.