### PR TITLE
chore: add long name alias

### DIFF
--- a/src/electron-build-tools
+++ b/src/electron-build-tools
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// This file just aliases `e` to the long name `electron-build-tools` as
+// well. This alias already exists in `@electron/build-tools`, but some
+// users of this repo may add a checkout directly to their PATH and not
+// go through `@electron/build-tools`, as that approach does not require
+// installing `@electron/build-tools` when switching Node.js versions with
+// nvm, for example. This alias is so that `electron/electron` can find us.
+
+import { existsSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ePath = resolve('./e');
+
+// Remap this filename to the regular `e` entry point since this is just an alias
+process.argv = process.argv.map((arg) => {
+  if (existsSync(arg)) {
+    return realpathSync(arg) === realpathSync(import.meta.filename) ? ePath : arg;
+  }
+  return arg;
+});
+
+import('./e').catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
With recent changes in `e/e` such as electron/electron#51034, users not using a `build-tools` installed via the `@electron/build-tools` package will have issues when running commands like `yarn lint` on `e/e` as we try to find `build-tools` via its long name (`electron-build-tools`) before invoking it, for safety.

While `@electron/build-tools` has the long name as a second bin name, any users directly pointing their path at a checkout of `build-tools` will not get that long name alias. So this PR adapts some of the code from `@electron/build-tools` and adds an alias file here directly.

cc @ckerr

[<img width="277" height="386" alt="reenable spacebar heating (xkcd)" src="https://github.com/user-attachments/assets/b3fe2999-dff1-4fd3-8926-855cb3c0f45f" />](https://xkcd.com/1172/)
