### PR TITLE
chore: drop CHROMIUM_BUILDTOOLS_PATH in favor of a buildtools symlink

### DIFF
--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -135,9 +135,6 @@
           "description": "Path to use as git cache for gclient"
         }
       },
-      "required": [
-        "CHROMIUM_BUILDTOOLS_PATH"
-      ],
       "additionalProperties": {
         "type": "string"
       },

--- a/example-configs/evm.base.yml
+++ b/example-configs/evm.base.yml
@@ -16,5 +16,4 @@ gen:
   out: Testing
 env:
   GIT_CACHE_PATH: /Users/user_name/.git_cache
-  CHROMIUM_BUILDTOOLS_PATH: /path/to/your/developer/folder/src/build-tools
 $schema: file:///Users/user_name/.electron_build_tools/evm-config.schema.json

--- a/example-configs/evm.chromium.yml
+++ b/example-configs/evm.chromium.yml
@@ -11,5 +11,4 @@ gen:
   out: Default
 env:
   GIT_CACHE_PATH: /Users/user_name/.git_cache
-  CHROMIUM_BUILDTOOLS_PATH: /path/to/your/developer/folder/src/build-tools
 $schema: file:///Users/user_name/.electron_build_tools/evm-config.schema.json

--- a/src/e-init.ts
+++ b/src/e-init.ts
@@ -10,7 +10,7 @@ import { program, Option } from 'commander';
 
 import * as evmConfig from './evm-config.js';
 import { color, fatal } from './utils/logging.js';
-import { resolvePath, ensureDir } from './utils/paths.js';
+import { resolvePath, ensureDir, ensureBuildtoolsSymlink } from './utils/paths.js';
 import * as depot from './utils/depot-tools.js';
 import { checkGlobalGitConfig } from './utils/git.js';
 import { ensureSDK } from './utils/sdk.js';
@@ -95,7 +95,6 @@ function createConfig(options: InitOptions): EvmConfig {
     },
     preserveSDK: 5,
     env: {
-      CHROMIUM_BUILDTOOLS_PATH: path.resolve(root, 'src', 'buildtools'),
       GIT_CACHE_PATH: gitCachePath
         ? resolvePath(gitCachePath)
         : path.resolve(homedir, '.git_cache'),
@@ -128,7 +127,8 @@ function ensureRoot(config: EvmConfig, force: boolean): void {
 
   ensureDir(root);
 
-  const hasOtherFiles = fs.readdirSync(root).some((file) => file !== '.gclient');
+  const allowedAtRoot = new Set(['.gclient', 'buildtools']);
+  const hasOtherFiles = fs.readdirSync(root).some((file) => !allowedAtRoot.has(file));
   if (hasOtherFiles && !force) {
     fatal(`Root ${color.path(root)} is not empty. Please choose a different root directory.`);
   }
@@ -139,6 +139,8 @@ function ensureRoot(config: EvmConfig, force: boolean): void {
   } else {
     runGClientConfig(config);
   }
+
+  ensureBuildtoolsSymlink(root);
 }
 
 program

--- a/src/e-sync.ts
+++ b/src/e-sync.ts
@@ -7,7 +7,7 @@ import { program } from 'commander';
 
 import * as evmConfig from './evm-config.js';
 import { fatal } from './utils/logging.js';
-import { ensureDir } from './utils/paths.js';
+import { ensureDir, ensureBuildtoolsSymlink } from './utils/paths.js';
 import * as depot from './utils/depot-tools.js';
 import { configureReclient } from './utils/setup-reclient-chromium.js';
 import { ensureSDK } from './utils/sdk.js';
@@ -78,6 +78,8 @@ function runGClientSync(syncArgs: string[], syncOpts: { threeWay?: boolean }): v
       : {},
   };
   depot.spawnSync(config, exec, args, opts, 'gclient sync failed');
+
+  ensureBuildtoolsSymlink(config.root);
 
   // Only set remotes if we're building an Electron target.
   if (config.defaultTarget !== 'chrome') {

--- a/src/e-worktree.ts
+++ b/src/e-worktree.ts
@@ -9,7 +9,7 @@ import { program } from 'commander';
 
 import * as evmConfig from './evm-config.js';
 import { color, fatal } from './utils/logging.js';
-import { resolvePath, deleteDir } from './utils/paths.js';
+import { resolvePath, deleteDir, ensureBuildtoolsSymlink } from './utils/paths.js';
 import * as depot from './utils/depot-tools.js';
 import type { SanitizedConfig } from './types.js';
 
@@ -103,7 +103,8 @@ program
       const newConfig: SanitizedConfig = structuredClone(sourceConfig);
       newConfig.root = targetRoot;
       newConfig.gen.out = options.out ?? sourceConfig.gen.out;
-      newConfig.env.CHROMIUM_BUILDTOOLS_PATH = path.join(targetRoot, 'src', 'buildtools');
+      delete newConfig.env.CHROMIUM_BUILDTOOLS_PATH;
+      ensureBuildtoolsSymlink(targetRoot);
 
       evmConfig.save(name, newConfig);
       console.log(`New build config ${color.config(name)} created in ${color.path(filename)}`);

--- a/src/evm-config.ts
+++ b/src/evm-config.ts
@@ -7,7 +7,7 @@ import * as YAML from 'yaml';
 import type { z } from 'zod';
 
 import { color, fatal } from './utils/logging.js';
-import { ensureDir } from './utils/paths.js';
+import { ensureDir, ensureBuildtoolsSymlink } from './utils/paths.js';
 import { evmConfigSchema, type EvmConfig, type SanitizedConfig } from './types.js';
 
 const configRoot = (): string =>
@@ -192,7 +192,7 @@ export function validateConfig(config: EvmConfig): ValidationError[] | undefined
 export function setEnvVar(name: string, key: string, value: string): void {
   const config = loadConfigFileRaw(name);
 
-  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+  config.env ??= {};
   config.env[key] = value;
 
   save(name, config);
@@ -292,12 +292,25 @@ export function sanitizeConfig(
     delete config.reclientServiceAddress;
   }
 
-  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+  config.env ??= {};
 
-  if (!config.env.CHROMIUM_BUILDTOOLS_PATH && config.root) {
-    const toolsPath = path.resolve(config.root, 'src', 'buildtools');
-    config.env.CHROMIUM_BUILDTOOLS_PATH = toolsPath;
-    changes.push(`defined ${color.config('CHROMIUM_BUILDTOOLS_PATH')}`);
+  // depot_tools deprecated CHROMIUM_BUILDTOOLS_PATH; rely on the buildtools
+  // symlink at the gclient root for auto-detection instead.
+  if (config.env.CHROMIUM_BUILDTOOLS_PATH) {
+    delete config.env.CHROMIUM_BUILDTOOLS_PATH;
+    changes.push(`removed deprecated ${color.config('CHROMIUM_BUILDTOOLS_PATH')}`);
+  }
+
+  if (config.root) {
+    try {
+      ensureBuildtoolsSymlink(config.root);
+    } catch (err) {
+      console.warn(
+        `${color.warn} Could not create buildtools symlink at ${color.path(
+          path.join(config.root, 'buildtools'),
+        )}: ${(err as Error).message}`,
+      );
+    }
   }
 
   if (changes.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,14 @@ const genSchema = z
 
 const envSchema = z
   .object({
+    // Deprecated: kept for backwards compatibility with existing configs.
+    // depot_tools' gclient_paths now auto-detects buildtools via a symlink
+    // at `<root>/buildtools`. See utils/paths.ts:ensureBuildtoolsSymlink.
     CHROMIUM_BUILDTOOLS_PATH: z
       .string()
       .min(1)
-      .describe('Path of Chromium buildtools in the checkout'),
+      .describe('Path of Chromium buildtools in the checkout')
+      .optional(),
     GIT_CACHE_PATH: z.string().min(1).describe('Path to use as git cache for gclient').optional(),
   })
   .catchall(z.string())

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -21,3 +21,33 @@ export function ensureDir(dir: string): void {
 export function deleteDir(dir: string): void {
   fs.rmSync(dir, { force: true, recursive: true });
 }
+
+// Creates `<root>/buildtools` -> `src/buildtools` so depot_tools' gclient_paths
+// auto-detection finds buildtools without needing CHROMIUM_BUILDTOOLS_PATH. The
+// gclient solution name is `src/electron`, which makes the supported lookup
+// (`<primary_solution>/buildtools` then `<gclient_root>/buildtools`) miss the
+// real buildtools dir at `<root>/src/buildtools`. A symlink at the gclient
+// root satisfies the second check.
+export function ensureBuildtoolsSymlink(root: string): void {
+  if (!fs.existsSync(root)) return;
+  const linkPath = path.join(root, 'buildtools');
+  const target = path.join('src', 'buildtools');
+  try {
+    const existing = fs.readlinkSync(linkPath);
+    if (existing === target) return;
+    // A different symlink — replace it.
+    fs.unlinkSync(linkPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EINVAL' || code === 'UNKNOWN') {
+      // Path exists but is not a symlink — leave it alone.
+      return;
+    }
+    if (code !== 'ENOENT') throw err;
+  }
+  // Windows junctions require an existing target; skip if not synced yet.
+  if (process.platform === 'win32' && !fs.existsSync(path.join(root, target))) {
+    return;
+  }
+  fs.symlinkSync(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir');
+}

--- a/tests/e-init.spec.mjs
+++ b/tests/e-init.spec.mjs
@@ -68,8 +68,13 @@ describe('e-init', () => {
       expect(remotes.origin).toStrictEqual('https://github.com/electron/electron.git');
       expect(remotes.fork).toStrictEqual('https://github.com/cool-fork/electron.git');
 
-      expect(config.env).toHaveProperty('CHROMIUM_BUILDTOOLS_PATH');
+      expect(config.env).not.toHaveProperty('CHROMIUM_BUILDTOOLS_PATH');
       expect(config.env).toHaveProperty('GIT_CACHE_PATH');
+
+      // ensureBuildtoolsSymlink should create a buildtools symlink at the root
+      const buildtoolsLink = path.resolve(root, 'buildtools');
+      expect(fs.lstatSync(buildtoolsLink).isSymbolicLink()).toStrictEqual(true);
+      expect(fs.readlinkSync(buildtoolsLink)).toStrictEqual(path.join('src', 'buildtools'));
 
       expect(config.gen.out).toStrictEqual('Testing');
 

--- a/tests/e-show.spec.mjs
+++ b/tests/e-show.spec.mjs
@@ -186,9 +186,8 @@ describe('e-show', () => {
         return acc;
       }, {});
     const envKeys = Object.keys(env).sort();
-    expect(envKeys).toEqual(
-      expect.arrayContaining(['CHROMIUM_BUILDTOOLS_PATH', 'GIT_CACHE_PATH', pathKey()]),
-    );
+    expect(envKeys).toEqual(expect.arrayContaining(['GIT_CACHE_PATH', pathKey()]));
+    expect(envKeys).not.toContain('CHROMIUM_BUILDTOOLS_PATH');
     expect(envKeys).toEqual(
       (isWindows ? expect : expect.not).arrayContaining(['DEPOT_TOOLS_WIN_TOOLCHAIN']),
     );

--- a/tests/evm-config.spec.mjs
+++ b/tests/evm-config.spec.mjs
@@ -21,9 +21,7 @@ const validConfig = {
     args: [],
     out: 'Testing',
   },
-  env: {
-    CHROMIUM_BUILDTOOLS_PATH: '/path/to/your/developer/folder/src/build-tools',
-  },
+  env: {},
 };
 
 const invalidConfig = {


### PR DESCRIPTION
depot_tools added a stderr warning in CL:7790518  declaring the env var "highly unsupported and may break gn." 

We were setting it because Electron's gclient solution is named `src/electron`, so depot_tools' auto-detection looks for buildtools at `<root>/src/electron/buildtools` and `<root>/buildtools` — neither exists in our layout (the real dir is `<root>/src/buildtools`).

Add ensureBuildtoolsSymlink() that creates `<root>/buildtools` -> `src/buildtools` (dir symlink on POSIX, junction on Windows). That satisfies depot_tools' supported `<gclient_root>/buildtools` lookup and lets us drop the env var entirely.

Wire the helper into `e init`, `e sync`, `e worktree add`, and sanitizeConfig so new and existing checkouts are migrated transparently. sanitizeConfig also strips CHROMIUM_BUILDTOOLS_PATH from saved configs on load. The schema keeps it as an optional field for backwards compatibility but no longer requires it.