### PR TITLE
chore: deprecate CHROMIUM_BUILDTOOLS_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,6 @@ See [`example-configs/`](./example-configs/) for annotated templates (`evm.base.
 | `remotes.electron.fork` | string (optional)                     | Optional fork remote URL                                                             |
 | `gen.args`              | string[]                              | GN arguments written to `out/<name>/args.gn`                                         |
 | `gen.out`               | string                                | Output directory name (e.g. `Testing`)                                               |
-| `env.CHROMIUM_BUILDTOOLS_PATH` | string                         | Path to Chromium buildtools inside the checkout                                      |
 | `env.GIT_CACHE_PATH`    | string (optional)                     | Git cache path for gclient (shared across configs)                                   |
 | `env.*`                 | string                                | Any additional env vars to inject into build-tools' subprocesses                     |
 | `defaultTarget`         | string (default: `electron`)          | Default ninja target for `e build`                                                   |
@@ -674,8 +673,7 @@ A config must supply **one** of:
 2. `root` + `remotes` + `gen` + `env` (a full Electron build), **or**
 3. `defaultTarget: chrome` + `root` + `env` (a Chromium-only build).
 
-**Config inheritance (`extends`)** — useful for keeping shared fields (git cache path, buildtools
-path, git remotes) in a base config and deriving per-variant configs from it:
+**Config inheritance (`extends`)** — useful for keeping shared fields (git cache path, git remotes) in a base config and deriving per-variant configs from it:
 
 ```yaml
 # evm.base.yml
@@ -684,7 +682,6 @@ remotes:
   electron:
     origin: git@github.com:electron/electron.git
 env:
-  CHROMIUM_BUILDTOOLS_PATH: /Users/me/src/electron/src/buildtools
   GIT_CACHE_PATH: /Users/me/.git_cache
 
 # evm.testing.yml

--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -135,9 +135,6 @@
           "description": "Path to use as git cache for gclient"
         }
       },
-      "required": [
-        "CHROMIUM_BUILDTOOLS_PATH"
-      ],
       "additionalProperties": {
         "type": "string"
       },

--- a/example-configs/evm.base.yml
+++ b/example-configs/evm.base.yml
@@ -16,5 +16,4 @@ gen:
   out: Testing
 env:
   GIT_CACHE_PATH: /Users/user_name/.git_cache
-  CHROMIUM_BUILDTOOLS_PATH: /path/to/your/developer/folder/src/build-tools
 $schema: file:///Users/user_name/.electron_build_tools/evm-config.schema.json

--- a/example-configs/evm.chromium.yml
+++ b/example-configs/evm.chromium.yml
@@ -11,5 +11,4 @@ gen:
   out: Default
 env:
   GIT_CACHE_PATH: /Users/user_name/.git_cache
-  CHROMIUM_BUILDTOOLS_PATH: /path/to/your/developer/folder/src/build-tools
 $schema: file:///Users/user_name/.electron_build_tools/evm-config.schema.json

--- a/src/evm-config.ts
+++ b/src/evm-config.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import * as YAML from 'yaml';
 import type { z } from 'zod';
 
+import { getChromiumBuildtoolsPath } from './utils/depot-tools.js';
 import { color, fatal } from './utils/logging.js';
 import { ensureDir } from './utils/paths.js';
 import { evmConfigSchema, type EvmConfig, type SanitizedConfig } from './types.js';
@@ -192,7 +193,7 @@ export function validateConfig(config: EvmConfig): ValidationError[] | undefined
 export function setEnvVar(name: string, key: string, value: string): void {
   const config = loadConfigFileRaw(name);
 
-  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+  config.env ??= {};
   config.env[key] = value;
 
   save(name, config);
@@ -292,12 +293,47 @@ export function sanitizeConfig(
     delete config.reclientServiceAddress;
   }
 
-  config.env ??= { CHROMIUM_BUILDTOOLS_PATH: '' };
+  config.env ??= {};
 
-  if (!config.env.CHROMIUM_BUILDTOOLS_PATH && config.root) {
-    const toolsPath = path.resolve(config.root, 'src', 'buildtools');
-    config.env.CHROMIUM_BUILDTOOLS_PATH = toolsPath;
-    changes.push(`defined ${color.config('CHROMIUM_BUILDTOOLS_PATH')}`);
+  if (config.root && fs.existsSync(config.root)) {
+    // Save off and delete the config value while we try resolving it
+    const configBuildtoolsPath = config.env.CHROMIUM_BUILDTOOLS_PATH;
+    delete config.env.CHROMIUM_BUILDTOOLS_PATH;
+
+    const resolvedBuildtoolsPath = getChromiumBuildtoolsPath(config);
+
+    if (resolvedBuildtoolsPath !== undefined) {
+      if (configBuildtoolsPath) {
+        // The path might not exist if there's a stale value in the config
+        const safeRealpath = (p: string): string => {
+          try {
+            return fs.realpathSync(p);
+          } catch {
+            return path.resolve(p);
+          }
+        };
+        if (safeRealpath(resolvedBuildtoolsPath) === safeRealpath(configBuildtoolsPath)) {
+          // The values match, so we don't need to do anything
+        } else {
+          console.warn(
+            `${color.warn} depot_tools resolves buildtools to ${color.path(resolvedBuildtoolsPath)}, ` +
+              `but ${color.config('CHROMIUM_BUILDTOOLS_PATH')} is set to ${color.path(configBuildtoolsPath)} ` +
+              `- using ${color.config('CHROMIUM_BUILDTOOLS_PATH')} as fallback`,
+          );
+          config.env.CHROMIUM_BUILDTOOLS_PATH = configBuildtoolsPath;
+        }
+      }
+    } else if (!configBuildtoolsPath) {
+      fatal(
+        `Could not resolve buildtools path via depot_tools for ${color.path(config.root)} and ` +
+          `${color.config('CHROMIUM_BUILDTOOLS_PATH')} is not set in your config. ` +
+          `Update ${color.cmd('depot_tools')} or add ` +
+          `${color.config('CHROMIUM_BUILDTOOLS_PATH')} to your config.`,
+      );
+    } else {
+      // Restore the config value for now as depot_tools isn't new enough
+      config.env.CHROMIUM_BUILDTOOLS_PATH = configBuildtoolsPath;
+    }
   }
 
   if (changes.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,8 @@ const envSchema = z
     CHROMIUM_BUILDTOOLS_PATH: z
       .string()
       .min(1)
-      .describe('Path of Chromium buildtools in the checkout'),
+      .describe('Path of Chromium buildtools in the checkout')
+      .optional(),
     GIT_CACHE_PATH: z.string().min(1).describe('Path to use as git cache for gclient').optional(),
   })
   .catchall(z.string())

--- a/src/utils/depot-tools.ts
+++ b/src/utils/depot-tools.ts
@@ -269,4 +269,39 @@ export function setAutoUpdate(enable: boolean): void {
   }
 }
 
+export function getChromiumBuildtoolsPath(config: ConfigLike): string | undefined {
+  // If it exists, remove CHROMIUM_BUILDTOOLS_PATH from the env,
+  // otherwise it will just get used by depot_tools as the override
+  const envChromiumBuildtoolsPath = process.env['CHROMIUM_BUILDTOOLS_PATH'];
+  delete process.env['CHROMIUM_BUILDTOOLS_PATH'];
+
+  const disableLogging = process.env['ELECTRON_DEPOT_TOOLS_DISABLE_LOG'];
+  process.env['ELECTRON_DEPOT_TOOLS_DISABLE_LOG'] = '1';
+
+  let result;
+  try {
+    result = spawnSync(
+      config,
+      'python3',
+      ['-c', 'from gclient_paths import GetBuildtoolsPath; print(GetBuildtoolsPath() or "")'],
+      { cwd: config.root, encoding: 'utf8', stdio: 'pipe', env: { PYTHONPATH: DEPOT_TOOLS_DIR } },
+    );
+  } catch {
+    return undefined;
+  } finally {
+    if (envChromiumBuildtoolsPath !== undefined) {
+      process.env['CHROMIUM_BUILDTOOLS_PATH'] = envChromiumBuildtoolsPath;
+    }
+    if (disableLogging !== undefined) {
+      process.env['ELECTRON_DEPOT_TOOLS_DISABLE_LOG'] = disableLogging;
+    } else {
+      delete process.env['ELECTRON_DEPOT_TOOLS_DISABLE_LOG'];
+    }
+  }
+
+  if (result.error || result.status !== 0) return undefined;
+  const out = result.stdout.trim();
+  return out || undefined;
+}
+
 export { DEPOT_TOOLS_DIR as path };

--- a/tests/e-init.spec.mjs
+++ b/tests/e-init.spec.mjs
@@ -68,7 +68,6 @@ describe('e-init', () => {
       expect(remotes.origin).toStrictEqual('https://github.com/electron/electron.git');
       expect(remotes.fork).toStrictEqual('https://github.com/cool-fork/electron.git');
 
-      expect(config.env).toHaveProperty('CHROMIUM_BUILDTOOLS_PATH');
       expect(config.env).toHaveProperty('GIT_CACHE_PATH');
 
       expect(config.gen.out).toStrictEqual('Testing');

--- a/tests/e-show.spec.mjs
+++ b/tests/e-show.spec.mjs
@@ -187,7 +187,7 @@ describe('e-show', () => {
       }, {});
     const envKeys = Object.keys(env).sort();
     expect(envKeys).toEqual(
-      expect.arrayContaining(['CHROMIUM_BUILDTOOLS_PATH', 'GIT_CACHE_PATH', pathKey()]),
+      expect.arrayContaining(['GIT_CACHE_PATH', pathKey()]),
     );
     expect(envKeys).toEqual(
       (isWindows ? expect : expect.not).arrayContaining(['DEPOT_TOOLS_WIN_TOOLCHAIN']),

--- a/tests/evm-config.spec.mjs
+++ b/tests/evm-config.spec.mjs
@@ -1,11 +1,21 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import YAML from 'yaml';
 
-const { sanitizeConfig, validateConfig, fetchByName } = require('../dist/evm-config.js');
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+vi.mock('../dist/utils/depot-tools.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getChromiumBuildtoolsPath: vi.fn(),
+  };
+});
+
+const { sanitizeConfig, validateConfig, fetchByName } = await import('../dist/evm-config.js');
+const { getChromiumBuildtoolsPath } = await import('../dist/utils/depot-tools.js');
 
 const validConfig = {
   $schema: 'file:///Users/user_name/.electron_build_tools/evm-config.schema.json',
@@ -21,9 +31,7 @@ const validConfig = {
     args: [],
     out: 'Testing',
   },
-  env: {
-    CHROMIUM_BUILDTOOLS_PATH: '/path/to/your/developer/folder/src/build-tools',
-  },
+  env: {},
 };
 
 const invalidConfig = {
@@ -143,3 +151,100 @@ describe('configValidationLevel', () => {
     processExitSpy.mockClear();
   });
 });
+
+describe('CHROMIUM_BUILDTOOLS_PATH resolution', () => {
+  let tmpRoot;
+  let resolvedBuildtoolsDir;
+  let altBuildtoolsDir;
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'evm-config-buildtools-'));
+    resolvedBuildtoolsDir = path.join(tmpRoot, 'src', 'buildtools');
+    altBuildtoolsDir = path.join(tmpRoot, 'other', 'buildtools');
+    fs.mkdirSync(resolvedBuildtoolsDir, { recursive: true });
+    fs.mkdirSync(altBuildtoolsDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.mocked(getChromiumBuildtoolsPath).mockReset();
+  });
+
+  const baseConfig = () => ({
+    ...validConfig,
+    root: tmpRoot,
+    env: {},
+  });
+
+  it('drops CHROMIUM_BUILDTOOLS_PATH when depot_tools resolves to the same path', () => {
+    vi.mocked(getChromiumBuildtoolsPath).mockReturnValue(resolvedBuildtoolsDir);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = sanitizeConfig('foobar', {
+      ...baseConfig(),
+      env: { CHROMIUM_BUILDTOOLS_PATH: resolvedBuildtoolsDir },
+    });
+
+    expect(config.env).not.toHaveProperty('CHROMIUM_BUILDTOOLS_PATH');
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('depot_tools resolves buildtools to'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('keeps CHROMIUM_BUILDTOOLS_PATH and warns when it disagrees with depot_tools', () => {
+    vi.mocked(getChromiumBuildtoolsPath).mockReturnValue(resolvedBuildtoolsDir);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = sanitizeConfig('foobar', {
+      ...baseConfig(),
+      env: { CHROMIUM_BUILDTOOLS_PATH: altBuildtoolsDir },
+    });
+
+    expect(config.env.CHROMIUM_BUILDTOOLS_PATH).toBe(altBuildtoolsDir);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('using'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not set CHROMIUM_BUILDTOOLS_PATH when depot_tools resolves and config has none', () => {
+    vi.mocked(getChromiumBuildtoolsPath).mockReturnValue(resolvedBuildtoolsDir);
+
+    const config = sanitizeConfig('foobar', baseConfig());
+
+    expect(config.env).not.toHaveProperty('CHROMIUM_BUILDTOOLS_PATH');
+  });
+
+  it('falls back to CHROMIUM_BUILDTOOLS_PATH when depot_tools cannot resolve', () => {
+    vi.mocked(getChromiumBuildtoolsPath).mockReturnValue(undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = sanitizeConfig('foobar', {
+      ...baseConfig(),
+      env: { CHROMIUM_BUILDTOOLS_PATH: altBuildtoolsDir },
+    });
+
+    expect(config.env.CHROMIUM_BUILDTOOLS_PATH).toBe(altBuildtoolsDir);
+    warnSpy.mockRestore();
+  });
+
+  it('fatals when depot_tools cannot resolve and there is no fallback', () => {
+    vi.mocked(getChromiumBuildtoolsPath).mockReturnValue(undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});
+
+    sanitizeConfig('foobar', baseConfig());
+
+    expect(exitSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Could not resolve buildtools path via depot_tools'),
+    );
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
Alternative to #855, when paired with electron/electron#51558. This PR checks if `depot_tools` has the fix to find `src/buildtools` with Electron, and if so it removes the `CHROMIUM_BUILDTOOLS_PATH` environment variable.

In the future we'll rip out the `CHROMIUM_BUILDTOOLS_PATH` logic all together once enough time has passed with the upstream `depot_tools` fix having landed.