### PR TITLE
feat: add an option to checkout Electron from a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ existing root to share it between build configs.
 | `--remote-build <target>`    | Remote-execution backend: `siso` (default) or `none`                             |
 | `--use-https`                | Set git remotes with `https://` URLs instead of `git@github.com:`                |
 | `--fork <user/electron>`     | Add a remote named `fork` pointing at the given GitHub fork                      |
+| `--fork-as-origin`           | Use `--fork` as the checkout `origin` and add `electron/electron` as `upstream`  |
+
+By default, `.gclient` checks out Electron from `https://github.com/electron/electron`. `--fork`
+adds a separate Git remote named `fork` and leaves `origin` pointing at upstream Electron. Use
+`--fork-as-origin` with `--fork` when the checkout source itself should be your fork; in that mode,
+`origin` points at the fork and `upstream` points at `electron/electron`.
 
 **Example**
 
@@ -651,8 +657,9 @@ See [`example-configs/`](./example-configs/) for annotated templates (`evm.base.
 | Field                   | Type                                  | Description                                                                          |
 |:------------------------|:--------------------------------------|:-------------------------------------------------------------------------------------|
 | `root`                  | string                                | Top directory — home of `.gclient`                                                   |
-| `remotes.electron.origin` | string                              | Origin git URL for `electron/electron` (ssh or https)                                |
-| `remotes.electron.fork` | string (optional)                     | Optional fork remote URL                                                             |
+| `remotes.electron.origin` | string                              | Origin git URL for the Electron checkout (ssh or https)                              |
+| `remotes.electron.upstream` | string (optional)                  | Optional upstream Electron remote URL, used when `origin` points at a fork           |
+| `remotes.electron.fork` | string (optional)                     | Optional additional `fork` remote URL                                                |
 | `gen.args`              | string[]                              | GN arguments written to `out/<name>/args.gn`                                         |
 | `gen.out`               | string                                | Output directory name (e.g. `Testing`)                                               |
 | `env.GIT_CACHE_PATH`    | string (optional)                     | Git cache path for gclient (shared across configs)                                   |

--- a/evm-config.schema.json
+++ b/evm-config.schema.json
@@ -70,6 +70,19 @@
               ],
               "description": "Origin remote"
             },
+            "upstream": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uri"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^git@.+$"
+                }
+              ],
+              "description": "Upstream remote"
+            },
             "fork": {
               "anyOf": [
                 {

--- a/src/e-init.ts
+++ b/src/e-init.ts
@@ -36,7 +36,29 @@ interface InitOptions {
   bootstrap?: boolean;
   remoteBuild: RemoteBuild;
   useHttps: boolean;
+  forkAsOrigin?: boolean;
   fork?: string;
+}
+
+function getRemotes(options: InitOptions): { origin: string; fork?: string; upstream?: string } {
+  const resolveGitUrl = (value: string): string =>
+    options.useHttps ? `https://github.com/${value}.git` : `git@github.com:${value}.git`;
+
+  const electronRemote = resolveGitUrl('electron/electron');
+
+  if (options.forkAsOrigin) {
+    const forkOpt = options.fork?.trim();
+    if (!forkOpt) {
+      fatal('--fork-as-origin requires --fork to be set with a valid GitHub repo (e.g. user/electron)');
+    }
+    const forkRemote = resolveGitUrl(forkOpt);
+    return { origin: forkRemote, upstream: electronRemote };
+  }
+
+  return {
+    origin: electronRemote,
+    ...(options.fork && { fork: resolveGitUrl(options.fork) }),
+  };
 }
 
 function createConfig(options: InitOptions): EvmConfig {
@@ -69,17 +91,6 @@ function createConfig(options: InitOptions): EvmConfig {
 
   if (options.targetCpu) gn_args.push(`target_cpu="${options.targetCpu}"`);
 
-  const electron = {
-    origin: options.useHttps
-      ? 'https://github.com/electron/electron.git'
-      : 'git@github.com:electron/electron.git',
-    ...(options.fork && {
-      fork: options.useHttps
-        ? `https://github.com/${options.fork}.git`
-        : `git@github.com:${options.fork}.git`,
-    }),
-  };
-
   const gitCachePath = process.env['GIT_CACHE_PATH'];
 
   return {
@@ -87,7 +98,7 @@ function createConfig(options: InitOptions): EvmConfig {
     remoteBuild: options.remoteBuild,
     root,
     remotes: {
-      electron,
+      electron: getRemotes(options),
     },
     gen: {
       args: gn_args,
@@ -106,6 +117,7 @@ function createConfig(options: InitOptions): EvmConfig {
 function runGClientConfig(config: EvmConfig): void {
   const { root } = config;
   if (!root) fatal('Config is missing root');
+  if (!config.remotes) fatal('Config is missing remotes');
   depot.ensure();
   const exec = 'gclient';
   const args = [
@@ -113,7 +125,7 @@ function runGClientConfig(config: EvmConfig): void {
     '--name',
     'src/electron',
     '--unmanaged',
-    'https://github.com/electron/electron',
+    config.remotes.electron.origin
   ];
   const opts = {
     cwd: root,
@@ -177,8 +189,13 @@ program
     false,
   )
   .option(
-    '--fork <username/electron>',
-    `Add a remote fork of Electron with the name 'fork'. This should take the format 'username/electron'`,
+    '--fork <user/electron>',
+    `Add a remote fork of Electron with the name 'fork'. Accepts the format 'user/electron'`,
+  )
+  .option(
+    '--fork-as-origin',
+    'Use --fork as the Electron checkout origin and add electron/electron as upstream',
+    false,
   )
   .action((name: string, options: InitOptions) => {
     if (options.import && !options.out) {

--- a/src/e-sync.ts
+++ b/src/e-sync.ts
@@ -25,25 +25,24 @@ function setRemotes(cwd: string, repo: ElectronRemotes): void {
 
   const entries: Array<[keyof ElectronRemotes, string | undefined]> = [
     ['origin', repo.origin],
+    ['upstream', repo.upstream],
     ['fork', repo.fork],
   ];
 
   for (const [remote, url] of entries) {
     if (!url) continue;
+    if (remote === 'origin') continue;
 
-    // First check that the fork remote exists.
-    if (remote === 'fork') {
-      const remotes = cp.execSync('git remote', { cwd }).toString().trim().split('\n');
+    // First check that non-origin remotes exist.
+    const remotes = cp.execSync('git remote', { cwd }).toString().trim().split('\n');
 
-      // If we've not added the fork remote, add it instead of updating the url.
-      if (!remotes.includes('fork')) {
-        cp.execSync(`git remote add ${remote} ${url}`, { cwd });
-        break;
-      }
+    // If we've not added the remote, add it instead of updating the url.
+    if (!remotes.includes(remote)) {
+      cp.execSync(`git remote add ${remote} ${url}`, { cwd });
+    } else {
+      cp.execSync(`git remote set-url ${remote} ${url}`, { cwd });
+      cp.execSync(`git remote set-url --push ${remote} ${url}`, { cwd });
     }
-
-    cp.execSync(`git remote set-url ${remote} ${url}`, { cwd });
-    cp.execSync(`git remote set-url --push ${remote} ${url}`, { cwd });
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ const gitUrl = z
 const electronRemotesSchema = z
   .strictObject({
     origin: gitUrl.describe('Origin remote'),
+    upstream: gitUrl.describe('Upstream remote').optional(),
     fork: gitUrl.describe('Fork remote').optional(),
   })
   .describe('Remotes for the Electron repo');

--- a/tests/e-init.spec.mjs
+++ b/tests/e-init.spec.mjs
@@ -76,6 +76,70 @@ describe('e-init', () => {
       expect(validationErrors).toBeFalsy();
     });
 
+    it('uses --fork and --fork-as-origin for the config and .gclient checkout URL', () => {
+      const root = path.resolve(sandbox.tmpdir, 'main');
+
+      const result = sandbox
+        .eInitRunner()
+        .name('special')
+        .root(root)
+        .fork('cool-fork/electron')
+        .forkAsOrigin()
+        .run();
+
+      expect(result.exitCode).toStrictEqual(0);
+
+      const configPath = path.resolve(sandbox.tmpdir, 'evm-config', 'evm.special.json');
+      const config = require(configPath);
+      expect(config.remotes.electron.origin).toStrictEqual('git@github.com:cool-fork/electron.git');
+      expect(config.remotes.electron.upstream).toStrictEqual('git@github.com:electron/electron.git');
+      expect(config.remotes.electron.fork).toBeUndefined();
+
+      const gclient = fs.readFileSync(path.resolve(root, '.gclient'), 'utf8');
+      expect(gclient).toContain('git@github.com:cool-fork/electron.git');
+      expect(gclient).not.toContain('git@github.com:electron/electron');
+    });
+
+    it('uses --fork, --fork-as-origin and --use-https for the config and .gclient checkout URL', () => {
+      const root = path.resolve(sandbox.tmpdir, 'main');
+
+      const result = sandbox
+        .eInitRunner()
+        .name('special')
+        .root(root)
+        .fork('cool-fork/electron')
+        .forkAsOrigin()
+        .useHttps()
+        .run();
+
+      expect(result.exitCode).toStrictEqual(0);
+
+      const configPath = path.resolve(sandbox.tmpdir, 'evm-config', 'evm.special.json');
+      const config = require(configPath);
+      expect(config.remotes.electron.origin).toStrictEqual('https://github.com/cool-fork/electron.git');
+      expect(config.remotes.electron.upstream).toStrictEqual('https://github.com/electron/electron.git');
+      expect(config.remotes.electron.fork).toBeUndefined();
+
+      const gclient = fs.readFileSync(path.resolve(root, '.gclient'), 'utf8');
+      expect(gclient).toContain('https://github.com/cool-fork/electron.git');
+      expect(gclient).not.toContain('https://github.com/electron/electron.git');
+    });
+
+    it('requires --fork when --fork-as-origin is passed', () => {
+      const root = path.resolve(sandbox.tmpdir, 'main');
+
+      const result = sandbox
+        .eInitRunner()
+        .name('special')
+        .root(root)
+        .forkAsOrigin()
+        .useHttps()
+        .run();
+
+      expect(result.exitCode).not.toStrictEqual(0);
+      expect(result.stderr).toEqual(expect.stringContaining('--fork-as-origin requires --fork'));
+    });
+
     it('logs an info message when the new build config root already has a .gclient file', () => {
       const root = path.resolve(sandbox.tmpdir, 'main');
 

--- a/tests/sandbox.js
+++ b/tests/sandbox.js
@@ -76,6 +76,10 @@ function eInitRunner(execOptions) {
       args.push(`--use-https`);
       return o;
     },
+    forkAsOrigin: () => {
+      args.push('--fork-as-origin');
+      return o;
+    },
     import: (val) => {
       args.push('--import', val);
       return o;


### PR DESCRIPTION
# Problem

Right now it's impossible to use `@electron/build-tools` to build from a fork. I actively maintain a fork of Electron with features that wouldn't make sense upstream, but I still regularly merge upstream to keep up with Chromium/Node upgrades.

Currently my workaround is to do this:
```bash
# Initialize
e init \
    --root ./electron \
    --import release \
    --remote-build "none" \
    --target-cpu "x64" \
    --fork cool-fork/electron \
    release-x64

# Replace origin with fork in `.gclient`
sed -i 's|https://github.com/electron/electron|https://github.com/cool-fork/electron|g' ./electron/.gclient

# Sync and build
e sync
e build electron:electron_dist_zip --no-remote
```

# Solution

This PR adds a flag for `--fork-as-origin` to `e init` for users who want to checkout Electron directly from their fork rather than `electron/electron`.

This would simplify my build script to this:
```bash
# Initialize, sync and build
e init \
    --root ./electron \
    --import release \
    --remote-build "none" \
    --target-cpu "x64" \
    --fork cool-fork/electron \
    --fork-as-origin \ # 👈 New flag
    release-x64

# Sync and build
e sync
e build electron:electron_dist_zip --no-remote
```

### Behavior

- The existing behavior from `--fork` is maintained:
  - `origin` and `.gclient` checkout from `electron/electron`
  - `fork` remote is pointed to the option passed by `--fork`
- When passing `--fork cool-fork/electron --fork-as-origin`:
  - `origin` and `.gclient` check out from the fork
  - `upstream` is added pointing at `electron/electron`

#### Testing

Added new tests for existing behavior, checking out with SSH, HTTPS and checking out with `--fork-as-origin`.