### PR TITLE
chore: build from src root

### DIFF
--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -78,6 +78,8 @@ async function runNinja(
   ninjaArgs: string[],
   genMode: GenMode,
 ): Promise<number> {
+  ninjaArgs.push('-C', path.join('out', config.gen.out));
+
   if (reclient.usingRemote && config.remoteBuild !== 'none') {
     const hasExecute = reclient.auth(config);
 
@@ -107,7 +109,7 @@ async function runNinja(
   const exec = os.platform() === 'win32' ? `${ninjaName}.bat` : ninjaName;
   const args = [...ninjaArgs, target];
   const opts: Partial<depot.DepotOpts> = {
-    cwd: evmConfig.outDir(config),
+    cwd: path.resolve(config.root, 'src'),
   };
   if (!reclient.usingRemote && config.reclient !== 'none') {
     opts.env = { RBE_remote_disabled: 'true' };


### PR DESCRIPTION
This aligns us with Chromium's build instructions, and fixes compatibility with some tooling like `tools/clang/scripts/analyze_includes.py`, which relies on that convention.