### PR TITLE
feat: allow overriding the siso RBE instance name via ELECTRON_RBE_INSTANCE

### DIFF
--- a/src/utils/siso.ts
+++ b/src/utils/siso.ts
@@ -4,7 +4,11 @@ import * as path from 'node:path';
 import * as reclient from './reclient.js';
 import type { SanitizedConfig } from '../types.js';
 
-const SISO_REAPI_INSTANCE = 'projects/electron-rbe/instances/default_instance';
+// The REv2 instance name namespaces the remote Action Cache. Release builds
+// override this to the release-only namespace (which their RBE token is
+// scoped to); everything else uses the shared CI/local namespace.
+const SISO_REAPI_INSTANCE =
+  process.env['ELECTRON_RBE_INSTANCE'] || 'projects/electron-rbe/instances/default_instance';
 const SISO_PROJECT = SISO_REAPI_INSTANCE.split('/')[1] ?? '';
 
 type ConfigLike = Pick<


### PR DESCRIPTION
The buildbarn deployment is gaining a release-only Action Cache namespace that only release-audience RBE tokens may write to (electron/infra `sam/bb-release-cache-isolation`, electron/not-goma-auth#43). The publish pipeline needs to point siso at that namespace while CI and local builds keep using the shared one.

This makes the REAPI instance name overridable via an `ELECTRON_RBE_INSTANCE` environment variable, defaulting to the existing `projects/electron-rbe/instances/default_instance` — no behaviour change for anyone who doesn't set it. The override flows into both the `SISO_REAPI_INSTANCE` env var and the `-reapi_instance` flag.

Follow-up once this lands and the SHA is bumped in electron/electron: the publish workflow segments set `ELECTRON_RBE_INSTANCE=projects/electron-rbe/instances/release` for jobs running in the `production-release` environment.