### PR TITLE
feat: add `e auto-roll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains helper/wrapper scripts to make building Electron easier
 - [Core workflow](#core-workflow): [`init`](#e-init) · [`sync`](#e-sync) · [`build`](#e-build)
 - [Running Electron](#running-electron): [`start`](#e-start) · [`node`](#e-node) · [`debug`](#e-debug) · [`test`](#e-test) · [`npm`](#e-npm)
 - [Inspecting state](#inspecting-state): [`show`](#e-show) · [`shell`](#e-shell)
-- [Working with code](#working-with-code): [`patches`](#e-patches) · [`open`](#e-open) · [`pr`](#e-pr) · [`download-dist`](#e-download-dist) · [`backport`](#e-backport) · [`cherry-pick`](#e-cherry-pick) · [`rcv`](#e-rcv)
+- [Working with code](#working-with-code): [`patches`](#e-patches) · [`open`](#e-open) · [`pr`](#e-pr) · [`download-dist`](#e-download-dist) · [`backport`](#e-backport) · [`cherry-pick`](#e-cherry-pick) · [`rcv`](#e-rcv) · [`auto-roll`](#e-auto-roll)
 - [Managing configs](#managing-configs): [`use`](#e-use) · [`remove`](#e-remove) · [`sanitize-config`](#e-sanitize-config) · [`worktree`](#e-worktree) · [`load-macos-sdk`](#e-load-macos-sdk)
 - [Infrastructure](#infrastructure): [`depot-tools`](#e-depot-tools) · [`gh-auth`](#e-gh-auth) · [`auto-update`](#e-auto-update)
 - [Configuration file reference](#configuration-file-reference)
@@ -511,6 +511,43 @@ range. Also regenerates generated files (`gen-hunspell-filenames.js`, `gen-libc+
 
 Requires a GitHub token — see [`e gh-auth`](#e-gh-auth).
 
+### `e auto-roll`
+
+Download a Chromium auto-roll produced by the [agent-workflows][agent-workflows] service and apply
+it on top of your local roller branch.
+
+```sh
+$ e auto-roll [options]
+```
+
+Authenticates with the service's Cloudflare Access (a browser window opens for SSO the first time;
+the token is then cached under `~/.cloudflared` and reused), lists recent successful auto-roll runs,
+and prompts you to pick one. It then shows the agent's summary and the roll's `base → head` and asks
+for confirmation.
+
+Before applying, it fetches the latest `roller/chromium/main` from your remote and brings your local
+branch up to it — this is what makes the roll's base commit available. Creating the branch or
+fast-forwarding it happens automatically; a hard reset that would **discard local commits** (your
+branch has diverged) asks for confirmation first. Pass `--no-fetch` to skip this and apply against
+your branch as-is.
+
+It then downloads the run's git bundle and replays the roll's commits onto your local
+`roller/chromium/main` (fast-forwarding when the branch is exactly at the roll's base, otherwise
+cherry-picking the commits on top). On a conflict it stops and leaves the bundle ref at
+`refs/auto-roll/<run>` so you can resolve and `git cherry-pick --continue`. The working tree must be
+clean before applying.
+
+**Options**
+
+| Option            | Description                                                              |
+|:------------------|:------------------------------------------------------------------------|
+| `--branch <name>` | Local roller branch to apply onto (default: `roller/chromium/main`)      |
+| `--remote <name>` | Remote to fetch the roller branch from (default: `origin`)              |
+| `--no-fetch`      | Don't fetch/reset the roller branch to its latest upstream first         |
+| `--limit <n>`     | How many recent runs to list (default: `30`)                            |
+| `--run <id>`      | Skip the picker and use this workflow run id directly                    |
+| `--no-apply`      | Download and extract the bundle but don't apply it                       |
+
 ## Managing configs
 
 ### `e use`
@@ -778,6 +815,7 @@ way to override args without editing the config file:
 $ CI=1 GN_EXTRA_ARGS="is_official_build=true" e build
 ```
 
+[agent-workflows]: https://github.com/electron/agent-workflows
 [depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 [gdb]: https://web.eecs.umich.edu/~sugih/pointers/summary.html
 [gn-configs]: https://github.com/electron/electron/tree/main/build/args

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "progress": "^2.0.3",
     "readline-sync": "^1.4.10",
     "semver": "^7.6.0",
+    "tweetnacl": "^1.0.3",
     "yaml": "^2.8.3",
     "zod": "^4.0.0"
   },

--- a/src/e-auto-roll.ts
+++ b/src/e-auto-roll.ts
@@ -1,0 +1,497 @@
+#!/usr/bin/env node
+
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as stream from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+import { program } from 'commander';
+import * as inquirer from '@inquirer/prompts';
+import debug from 'debug';
+import extractZip from 'extract-zip';
+
+import * as evmConfig from './evm-config.js';
+import { AccessClient } from './utils/cf-access.js';
+import { progressStream } from './utils/download.js';
+import { color, fatal } from './utils/logging.js';
+
+const d = debug('build-tools:auto-roll');
+
+/** The agent-workflows dashboard/API, fronted by Cloudflare Access. */
+const AGENTS_URL = new URL('https://agents.electronjs.org');
+/** Branch the chromium roller pushes to (and that we replay rolls onto). */
+const DEFAULT_ROLLER_BRANCH = 'roller/chromium/main';
+/** Artifact name prefix the workflow uses for the git bundle. */
+const BUNDLE_ARTIFACT_PREFIX = 'chromium-roll-';
+const BUNDLE_FILE = 'roll.bundle';
+const BUNDLE_META_FILE = 'bundle.meta';
+const ROLL_SUMMARY_FILE = 'roll-summary.md';
+
+interface RunSummary {
+  id: number;
+  run_number: number;
+  status: string;
+  conclusion: string | null;
+  head_sha: string;
+  actor: string | null;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  run_started_at: string | null;
+}
+
+interface RunsResponse {
+  workflow_runs: RunSummary[];
+  total_count: number;
+}
+
+interface ArtifactMeta {
+  id: number;
+  name: string;
+  size_in_bytes: number;
+  created_at: string | null;
+  expired: boolean;
+}
+
+interface AutoRollOptions {
+  branch: string;
+  remote: string;
+  fetch: boolean;
+  limit: string;
+  apply: boolean;
+  run?: string;
+}
+
+function shortSha(sha: string): string {
+  return sha.slice(0, 9);
+}
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return 'unknown';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 'unknown';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+async function apiJson<T>(client: AccessClient, requestPath: string): Promise<T> {
+  const res = await client.request(requestPath, { headers: { Accept: 'application/json' } });
+  if (res.status !== 200) {
+    fatal(`Request to ${requestPath} failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function apiText(client: AccessClient, requestPath: string): Promise<string> {
+  const res = await client.request(requestPath);
+  if (res.status === 404) return '';
+  if (res.status !== 200) {
+    fatal(`Request to ${requestPath} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.text();
+}
+
+/** Pick the newest non-expired artifact whose name starts with the prefix. */
+function pickBundleArtifact(artifacts: ArtifactMeta[]): ArtifactMeta | null {
+  const matches = artifacts
+    .filter((a) => a.name.startsWith(BUNDLE_ARTIFACT_PREFIX) && !a.expired)
+    .sort((a, b) => {
+      const at = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const bt = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return bt - at;
+    });
+  return matches[0] ?? null;
+}
+
+function parseBundleMeta(text: string): { base?: string; head?: string } {
+  const meta: { base?: string; head?: string } = {};
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^(\w+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    if (m[1] === 'base') meta.base = m[2]!.trim();
+    else if (m[1] === 'head') meta.head = m[2]!.trim();
+  }
+  return meta;
+}
+
+function git(
+  electronDir: string,
+  args: string[],
+  opts: { capture?: boolean } = {},
+): cp.SpawnSyncReturns<string> {
+  if (!opts.capture) {
+    console.log(color.childExec('git', args, { cwd: electronDir }));
+  }
+  return cp.spawnSync('git', args, {
+    cwd: electronDir,
+    encoding: 'utf8',
+    stdio: opts.capture ? 'pipe' : 'inherit',
+  });
+}
+
+async function downloadBundle(
+  client: AccessClient,
+  artifact: ArtifactMeta,
+  destDir: string,
+): Promise<string> {
+  // The download endpoint 302s to a short-lived signed blob URL. Capture the
+  // redirect ourselves so we can fetch the (non-Access) storage URL without
+  // leaking the Access token to it.
+  const res = await client.request(`/api/artifacts/${artifact.id}/download`);
+  const location = res.status >= 300 && res.status < 400 ? res.headers.get('location') : null;
+  if (!location) {
+    fatal(`Unexpected response downloading artifact ${artifact.id}: ${res.status}`);
+  }
+
+  const zipPath = path.join(destDir, 'artifact.zip');
+  const zipRes = await fetch(location);
+  if (!zipRes.ok || !zipRes.body) {
+    fatal(`Failed to download artifact zip: ${zipRes.status} ${zipRes.statusText}`);
+  }
+
+  const total = Number(zipRes.headers.get('content-length') ?? 0);
+  const source = stream.Readable.fromWeb(
+    zipRes.body as Parameters<typeof stream.Readable.fromWeb>[0],
+  );
+  const out = fs.createWriteStream(zipPath);
+  if (total > 0 && process.stdout.isTTY) {
+    await pipeline(source, progressStream(total, '  [:bar] :mbRateMB/s :percent :etas'), out);
+  } else {
+    await pipeline(source, out);
+  }
+
+  const extractDir = path.join(destDir, 'extracted');
+  await extractZip(zipPath, { dir: extractDir });
+  const bundlePath = path.join(extractDir, BUNDLE_FILE);
+  if (!fs.existsSync(bundlePath)) {
+    fatal(`Artifact ${artifact.name} did not contain ${BUNDLE_FILE}`);
+  }
+  return extractDir;
+}
+
+/**
+ * Bring the local roller branch in line with its upstream before applying:
+ * fetch the latest `rollerBranch` from `remote`, then move `localBranch` to
+ * that tip. This is what makes the roll's base commit available locally.
+ *
+ * Creating the branch or fast-forwarding it is non-destructive and happens
+ * silently. A hard reset that would *discard* local commits (the branch has
+ * diverged from upstream) prompts for confirmation first.
+ */
+async function syncRollerBranch(
+  electronDir: string,
+  remote: string,
+  rollerBranch: string,
+  localBranch: string,
+): Promise<void> {
+  console.log(`${color.info} Fetching latest ${color.config(`${remote}/${rollerBranch}`)}…`);
+  if (git(electronDir, ['fetch', remote, rollerBranch]).status !== 0) {
+    fatal(`Failed to fetch ${rollerBranch} from ${remote}`);
+  }
+  const remoteTip = git(electronDir, ['rev-parse', 'FETCH_HEAD'], { capture: true }).stdout.trim();
+  if (!remoteTip) fatal('Could not resolve the fetched roller branch tip (FETCH_HEAD)');
+
+  const localExists =
+    git(electronDir, ['rev-parse', '--verify', '--quiet', `refs/heads/${localBranch}`], {
+      capture: true,
+    }).status === 0;
+
+  if (!localExists) {
+    console.log(
+      `${color.info} Creating ${color.config(localBranch)} at ${color.git(shortSha(remoteTip))}`,
+    );
+    if (git(electronDir, ['checkout', '-b', localBranch, remoteTip]).status !== 0) {
+      fatal(`Could not create ${localBranch} at ${shortSha(remoteTip)}`);
+    }
+    return;
+  }
+
+  const localTip = git(electronDir, ['rev-parse', localBranch], { capture: true }).stdout.trim();
+  if (localTip === remoteTip) {
+    if (git(electronDir, ['checkout', localBranch]).status !== 0) {
+      fatal(`Could not check out ${localBranch}`);
+    }
+    console.log(
+      `${color.info} ${color.config(localBranch)} is already at the latest ${rollerBranch}`,
+    );
+    return;
+  }
+
+  // Commits on the local branch the upstream tip can't reach — i.e. work that a
+  // hard reset would throw away.
+  const lost = git(electronDir, ['rev-list', `${remoteTip}..${localTip}`], {
+    capture: true,
+  }).stdout.trim();
+
+  if (lost) {
+    const lostLog = git(electronDir, ['log', '--oneline', `${remoteTip}..${localTip}`], {
+      capture: true,
+    }).stdout.trim();
+    console.log(
+      `\n${color.warn} ${color.config(localBranch)} has local commits that aren't on ${remote}/${rollerBranch}:\n\n${lostLog}\n`,
+    );
+    const ok = await inquirer.confirm({
+      default: false,
+      message: `Hard-reset ${localBranch} to ${shortSha(remoteTip)} and DISCARD the ${lost.split('\n').length} commit(s) above?`,
+    });
+    if (!ok) {
+      fatal(
+        `Aborted to preserve your local commits. Push or stash them, or re-run with a different ${color.cmd('--branch')}.`,
+      );
+    }
+  }
+
+  if (git(electronDir, ['checkout', localBranch]).status !== 0) {
+    fatal(`Could not check out ${localBranch}`);
+  }
+  if (git(electronDir, ['reset', '--hard', remoteTip]).status !== 0) {
+    fatal(`Could not reset ${localBranch} to ${shortSha(remoteTip)}`);
+  }
+  console.log(
+    `${color.success} ${color.config(localBranch)} reset to latest ${rollerBranch} ` +
+      `(${color.git(shortSha(remoteTip))})`,
+  );
+}
+
+function applyRoll(
+  electronDir: string,
+  extractDir: string,
+  branch: string,
+  runId: number,
+  remote: string,
+): void {
+  const bundlePath = path.join(extractDir, BUNDLE_FILE);
+  const metaPath = path.join(extractDir, BUNDLE_META_FILE);
+
+  const meta = fs.existsSync(metaPath) ? parseBundleMeta(fs.readFileSync(metaPath, 'utf8')) : {};
+  if (!meta.base || !meta.head) {
+    fatal(`${BUNDLE_META_FILE} is missing base/head — refusing to apply an unverifiable bundle`);
+  }
+  const { base, head } = meta as { base: string; head: string };
+
+  // The bundle is rooted at the roller/chromium/main tip the roll was built
+  // from. If our checkout doesn't already have that commit, fetch it by SHA —
+  // it's a real commit on the remote (unless the roller branch has since been
+  // force-pushed past this roll, in which case it's been GC'd).
+  const haveBase = () =>
+    git(electronDir, ['cat-file', '-e', `${base}^{commit}`], { capture: true }).status === 0;
+  if (!haveBase()) {
+    console.log(`${color.info} Fetching the roll's base commit ${shortSha(base)} from ${remote}…`);
+    git(electronDir, ['fetch', remote, base], { capture: true });
+  }
+
+  // Verify the bundle is self-consistent and its prerequisite (base) commit is
+  // present before we touch any branch.
+  const verify = git(electronDir, ['bundle', 'verify', bundlePath], { capture: true });
+  if (verify.status !== 0 || !haveBase()) {
+    if (verify.stderr || verify.stdout) console.error(verify.stderr || verify.stdout);
+    fatal(
+      `The roll's base commit ${shortSha(base)} isn't available on ${remote}. The roller branch ` +
+        `was likely force-pushed past this roll (its base has been garbage-collected) — pick a ` +
+        `more recent roll.`,
+    );
+  }
+
+  const tempRef = `refs/auto-roll/${runId}`;
+  if (git(electronDir, ['fetch', bundlePath, `${head}:${tempRef}`]).status !== 0) {
+    fatal('Failed to fetch the roll commits out of the bundle');
+  }
+
+  // Ensure the target branch exists; anchor a new one at base if it doesn't.
+  const branchExists =
+    git(electronDir, ['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], {
+      capture: true,
+    }).status === 0;
+  if (!branchExists) {
+    console.log(
+      `${color.warn} Local branch ${color.config(branch)} doesn't exist — creating it at the roll's base ${shortSha(base)}`,
+    );
+    if (git(electronDir, ['branch', branch, base]).status !== 0) {
+      fatal(`Could not create branch ${branch} at ${shortSha(base)}`);
+    }
+  }
+
+  if (git(electronDir, ['checkout', branch]).status !== 0) {
+    fatal(`Could not check out ${branch}`);
+  }
+
+  const branchTip = git(electronDir, ['rev-parse', branch], { capture: true }).stdout.trim();
+
+  let applied: cp.SpawnSyncReturns<string>;
+  if (branchTip === base) {
+    // Local branch is exactly where the roll started — fast-forward.
+    console.log(`${color.info} ${color.config(branch)} is at the roll base; fast-forwarding`);
+    applied = git(electronDir, ['merge', '--ff-only', tempRef]);
+  } else {
+    // Branch has diverged from the roll's base — replay the roll's commits on
+    // top of wherever the branch is now.
+    console.log(
+      `${color.info} Replaying roll commits ${shortSha(base)}..${shortSha(head)} onto ${color.config(branch)}`,
+    );
+    applied = git(electronDir, ['cherry-pick', `${base}..${tempRef}`]);
+  }
+
+  if (applied.status !== 0) {
+    console.error(
+      `\n${color.err} Applying the roll hit a conflict. The bundle ref is kept at ` +
+        `${color.config(tempRef)} for reference.\n` +
+        `Resolve the conflicts, then ${color.cmd('git cherry-pick --continue')} ` +
+        `(or ${color.cmd('git cherry-pick --abort')} to back out).`,
+    );
+    process.exit(applied.status ?? 1);
+  }
+
+  // Success — drop the temporary bundle ref and report the new tip.
+  git(electronDir, ['update-ref', '-d', tempRef], { capture: true });
+  const newTip = git(electronDir, ['rev-parse', branch], { capture: true }).stdout.trim();
+  console.log(
+    `\n${color.success} ${color.config(branch)} now at ${color.git(shortSha(newTip))} ` +
+      `(roll head ${shortSha(head)})`,
+  );
+}
+
+program
+  .description(
+    'List Chromium auto-rolls produced by the agent-workflows service, download one, and apply it on top of the local roller branch',
+  )
+  .option('--branch <name>', 'Local roller branch to apply onto', DEFAULT_ROLLER_BRANCH)
+  .option('--remote <name>', 'Remote to fetch the roller branch from', 'origin')
+  .option(
+    '--no-fetch',
+    "Don't fetch/reset the roller branch to its latest upstream before applying",
+  )
+  .option('--limit <n>', 'How many recent runs to list', '30')
+  .option('--run <id>', 'Skip the picker and use this workflow run id directly')
+  .option('--no-apply', 'Download and extract the bundle but do not apply it')
+  .action(async (options: AutoRollOptions) => {
+    const config = evmConfig.current();
+    const electronDir = path.resolve(config.root, 'src', 'electron');
+    if (!fs.existsSync(path.join(electronDir, '.git'))) {
+      fatal(
+        `No Electron checkout found at ${color.path(electronDir)} — run ${color.cmd('e sync')} first`,
+      );
+    }
+
+    // Refuse to apply onto a dirty tree; we won't risk clobbering local work.
+    if (options.apply) {
+      const status = git(electronDir, ['status', '--porcelain'], { capture: true });
+      if (status.status !== 0 || status.stdout.trim().length !== 0) {
+        fatal(
+          "Your Electron working tree isn't clean. Commit or stash your changes (or pass " +
+            `${color.cmd('--no-apply')} to just download) and try again.`,
+        );
+      }
+    }
+
+    const client = await AccessClient.create(AGENTS_URL);
+
+    // Resolve which run to download.
+    let runId: number;
+    if (options.run) {
+      runId = Number(options.run);
+      if (!Number.isInteger(runId))
+        fatal(`--run must be a numeric workflow run id, got "${options.run}"`);
+    } else {
+      const limit = Math.min(Math.max(Number(options.limit) || 30, 1), 100);
+      console.log(`${color.info} Fetching recent Chromium auto-rolls…`);
+      const runs = await apiJson<RunsResponse>(
+        client,
+        `/api/chromium-upgrade/runs?perPage=${limit}&warm=false`,
+      );
+      const successful = runs.workflow_runs.filter(
+        (r) => r.status === 'completed' && r.conclusion === 'success',
+      );
+      if (successful.length === 0) {
+        fatal('No successful auto-roll runs found to download.');
+      }
+
+      runId = await inquirer.select({
+        message: 'Which auto-roll do you want to download?',
+        choices: successful.map((r) => ({
+          name: `#${r.run_number}  ${timeAgo(r.run_started_at ?? r.created_at).padEnd(8)}  ${shortSha(r.head_sha)}  ${r.actor ?? '—'}`,
+          value: r.id,
+          description: r.html_url,
+        })),
+      });
+    }
+
+    // Find the bundle artifact for the chosen run.
+    const artifacts = await apiJson<ArtifactMeta[]>(
+      client,
+      `/api/chromium-upgrade/runs/${runId}/artifacts`,
+    );
+    const bundle = pickBundleArtifact(artifacts);
+    if (!bundle) {
+      fatal(
+        `Run ${runId} has no downloadable ${BUNDLE_ARTIFACT_PREFIX}* bundle. It may have produced ` +
+          'no changes, failed before bundling, or its artifact expired (14-day retention).',
+      );
+    }
+    d('selected bundle artifact %o', bundle);
+
+    // Show the agent's summary + base/head and confirm before downloading.
+    const summary = await apiText(
+      client,
+      `/api/artifacts/${bundle.id}/file?name=${ROLL_SUMMARY_FILE}`,
+    );
+    const metaText = await apiText(
+      client,
+      `/api/artifacts/${bundle.id}/file?name=${BUNDLE_META_FILE}`,
+    );
+    const meta = parseBundleMeta(metaText);
+    const sizeMb = (bundle.size_in_bytes / (1024 * 1024)).toFixed(1);
+
+    console.log(`\n${color.info} ${bundle.name} (${sizeMb} MB)`);
+    if (meta.base && meta.head) {
+      console.log(
+        `       base ${color.git(shortSha(meta.base))} → head ${color.git(shortSha(meta.head))}`,
+      );
+    }
+    if (summary.trim()) {
+      const preview = summary.trim().split(/\r?\n/).slice(0, 12).join('\n');
+      console.log(`\n${preview}\n`);
+    }
+
+    if (!options.apply) {
+      const destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-auto-roll-'));
+      const extractDir = await downloadBundle(client, bundle, destDir);
+      console.log(
+        `${color.success} Downloaded and extracted to ${color.path(extractDir)} ` +
+          `(not applied — ${color.cmd('--no-apply')})`,
+      );
+      return;
+    }
+
+    const proceed = await inquirer.confirm({
+      default: true,
+      message: `Download this roll and apply it onto ${options.branch}?`,
+    });
+    if (!proceed) {
+      console.log(`${color.info} Aborted.`);
+      return;
+    }
+
+    const destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'electron-auto-roll-'));
+    try {
+      // Fetch the latest roller branch (and bring the local branch up to it) so
+      // the roll's base commit is present before we try to apply it.
+      if (options.fetch) {
+        await syncRollerBranch(electronDir, options.remote, DEFAULT_ROLLER_BRANCH, options.branch);
+      }
+      const extractDir = await downloadBundle(client, bundle, destDir);
+      applyRoll(electronDir, extractDir, options.branch, runId, options.remote);
+    } finally {
+      fs.rmSync(destDir, { recursive: true, force: true });
+    }
+  });
+
+if (import.meta.main) {
+  program.parse(process.argv);
+}

--- a/src/e-auto-roll.ts
+++ b/src/e-auto-roll.ts
@@ -4,7 +4,6 @@ import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as stream from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 import { program } from 'commander';
@@ -157,14 +156,11 @@ async function downloadBundle(
   }
 
   const total = Number(zipRes.headers.get('content-length') ?? 0);
-  const source = stream.Readable.fromWeb(
-    zipRes.body as Parameters<typeof stream.Readable.fromWeb>[0],
-  );
   const out = fs.createWriteStream(zipPath);
   if (total > 0 && process.stdout.isTTY) {
-    await pipeline(source, progressStream(total, '  [:bar] :mbRateMB/s :percent :etas'), out);
+    await pipeline(zipRes.body, progressStream(total, '  [:bar] :mbRateMB/s :percent :etas'), out);
   } else {
-    await pipeline(source, out);
+    await pipeline(zipRes.body, out);
   }
 
   const extractDir = path.join(destDir, 'extracted');
@@ -274,7 +270,7 @@ function applyRoll(
   if (!meta.base || !meta.head) {
     fatal(`${BUNDLE_META_FILE} is missing base/head — refusing to apply an unverifiable bundle`);
   }
-  const { base, head } = meta as { base: string; head: string };
+  const { base, head } = meta;
 
   // The bundle is rooted at the roller/chromium/main tip the roll was built
   // from. If our checkout doesn't already have that commit, fetch it by SHA —

--- a/src/e.ts
+++ b/src/e.ts
@@ -221,7 +221,11 @@ program
     'rcv <roll-pr> [chromium-version]',
     'Attempts to reconstruct an intermediate Chromium version from a roll PR',
   )
-  .alias('reconstruct-chromium-version');
+  .alias('reconstruct-chromium-version')
+  .command(
+    'auto-roll [options]',
+    'Download a Chromium auto-roll from the agent-workflows service and apply it onto the roller branch',
+  );
 
 program
   .command('load-macos-sdk [version]')

--- a/src/utils/cf-access.ts
+++ b/src/utils/cf-access.ts
@@ -1,0 +1,343 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import nacl from 'tweetnacl';
+import open from 'open';
+import debug from 'debug';
+
+import { color } from './logging.js';
+
+const d = debug('build-tools:cf-access');
+
+// Ported from cloudflare/cloudflared's `token` package so we can complete the
+// Cloudflare Access browser-login "dance" ourselves without shelling out to the
+// `cloudflared` binary. See:
+//   https://github.com/cloudflare/cloudflared/blob/master/token/token.go
+//   https://github.com/cloudflare/cloudflared/blob/master/token/transfer.go
+
+const ACCESS_LOGIN_WORKER_PATH = '/cdn-cgi/access/login';
+/** Cloudflare's hosted login-helper / token-transfer service. */
+const TRANSFER_STORE_URL = 'https://login.cloudflareaccess.org/';
+/** Header the CF edge consumes and converts into `cf-access-jwt-assertion`. */
+export const CF_ACCESS_TOKEN_HEADER = 'Cf-Access-Token';
+
+const USER_AGENT = 'electron-build-tools';
+/** Per-poll timeout. The transfer service long-polls, holding the request
+ *  open until the user finishes login or it times out server-side. */
+const POLL_TIMEOUT_MS = 60_000;
+const POLL_ATTEMPTS = 12;
+
+export interface AppInfo {
+  /** The Access team domain, e.g. `electronjs.cloudflareaccess.com`. */
+  authDomain: string;
+  /** The AUD tag of the Access application fronting the service. */
+  appAUD: string;
+  /** The application hostname, e.g. `agents.electronjs.org`. Used for the
+   *  on-disk token cache filename (kept compatible with cloudflared's). */
+  appDomain: string;
+}
+
+/** `~/.cloudflared` — shared with the cloudflared binary so a token either of
+ *  us fetches is reusable by the other. Created lazily with 0700 perms. */
+function configDir(): string {
+  const dir = path.join(os.homedir(), '.cloudflared');
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  return dir;
+}
+
+function appTokenPath(appInfo: AppInfo): string {
+  const name = `${appInfo.appDomain}-${appInfo.appAUD}-token`
+    .replace(/\//g, '-')
+    .replace(/\*/g, '-');
+  return path.join(configDir(), name);
+}
+
+/** Standard (padded) base64url, matching Go's `base64.URLEncoding`. */
+function base64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+interface JwtPayload {
+  exp?: number;
+  email?: string;
+}
+
+function decodeJwtPayload(jwt: string): JwtPayload | null {
+  const parts = jwt.split('.');
+  if (parts.length < 2 || !parts[1]) return null;
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+function isExpired(jwt: string): boolean {
+  const payload = decodeJwtPayload(jwt);
+  if (!payload?.exp) return true;
+  return Math.floor(Date.now() / 1000) >= payload.exp;
+}
+
+/**
+ * Discover the Access application fronting `appURL` by issuing a HEAD request
+ * and inspecting the redirect to the login worker. Mirrors
+ * `token.GetAppInfo`.
+ */
+export async function getAppInfo(appURL: URL): Promise<AppInfo> {
+  // First hop: the edge 302s an unauthenticated request to the team's login
+  // worker, whose URL carries the AUD as the `kid` query param.
+  const res = await fetch(appURL.toString(), {
+    method: 'HEAD',
+    redirect: 'manual',
+    headers: { 'User-Agent': USER_AGENT },
+  });
+
+  const location = res.headers.get('location');
+  if (res.status >= 300 && res.status < 400 && location) {
+    const loginURL = new URL(location);
+    if (loginURL.pathname.includes(ACCESS_LOGIN_WORKER_PATH)) {
+      const aud = loginURL.searchParams.get('kid');
+      if (!aud) throw new Error('Access login redirect did not contain an app AUD (kid)');
+      return {
+        authDomain: loginURL.hostname,
+        appAUD: aud,
+        // CF-Access-Domain is the app hostname; derive it directly rather than
+        // chasing it through a second redirect hop.
+        appDomain: appURL.hostname,
+      };
+    }
+  }
+
+  // A 401/403 carries the AUD in a header instead of a redirect.
+  const audHeader = res.headers.get('cf-access-aud');
+  if (audHeader) {
+    const domain = res.headers.get('cf-access-domain') || appURL.hostname;
+    return { authDomain: domain, appAUD: audHeader, appDomain: appURL.hostname };
+  }
+
+  throw new Error(
+    `No Cloudflare Access application found in front of ${appURL.origin} (status ${res.status}). ` +
+      `Is the service reachable and Access-protected?`,
+  );
+}
+
+function readCachedToken(appInfo: AppInfo): string | null {
+  const tokenPath = appTokenPath(appInfo);
+  let content: string;
+  try {
+    content = fs.readFileSync(tokenPath, 'utf8').trim();
+  } catch {
+    return null;
+  }
+  if (!content) return null;
+  if (isExpired(content)) {
+    d('cached token at %s is expired; discarding', tokenPath);
+    try {
+      fs.rmSync(tokenPath);
+    } catch {
+      /* best effort */
+    }
+    return null;
+  }
+  return content;
+}
+
+function writeCachedToken(appInfo: AppInfo, token: string): void {
+  fs.writeFileSync(appTokenPath(appInfo), token, { mode: 0o600 });
+}
+
+/**
+ * Build the `cdn-cgi/access/cli` URL the browser is sent to. Mirrors
+ * `token.buildRequestURL` with `useHostOnly` + `cli` + `autoClose` all set.
+ */
+function buildLoginURL(appURL: URL, appAUD: string, publicKey: string): string {
+  const host = appURL.hostname;
+  // The value CF redirects the browser to after a successful login. It carries
+  // our public key (as `token`) and the AUD so the login worker knows which
+  // app + transfer slot to post the encrypted token to.
+  const redirectURL = new URL(`https://${host}`);
+  redirectURL.searchParams.set('aud', appAUD);
+  redirectURL.searchParams.set('token', publicKey);
+
+  const cli = new URL(`https://${host}/cdn-cgi/access/cli`);
+  cli.searchParams.set('aud', appAUD);
+  cli.searchParams.set('token', publicKey);
+  cli.searchParams.set('redirect_url', redirectURL.toString());
+  cli.searchParams.set('send_org_token', 'true');
+  cli.searchParams.set('edge_token_transfer', 'true');
+  cli.searchParams.set('close_interstitial', 'true');
+  return cli.toString();
+}
+
+interface TransferResponse {
+  app_token?: string;
+  org_token?: string;
+}
+
+/** One long-poll of the transfer store. Resolves to the decrypted token JSON,
+ *  or null if the resource isn't ready yet (user hasn't finished logging in). */
+async function pollTransfer(
+  url: string,
+  encrypter: { secretKey: Uint8Array },
+): Promise<TransferResponse | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), POLL_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (res.status >= 500) {
+    throw new Error(`Transfer service error ${res.status}: ${await res.text()}`);
+  }
+  if (res.status !== 200) {
+    // Not ready yet — the user still needs to complete the browser login.
+    return null;
+  }
+
+  const senderPublicKey = res.headers.get('service-public-key');
+  if (!senderPublicKey) throw new Error('Transfer response missing service-public-key header');
+
+  // Body is base64(nonce[24] || box) per token/transfer.go + token/encrypt.go.
+  const wire = new Uint8Array(Buffer.from((await res.text()).trim(), 'base64'));
+  const nonce = wire.slice(0, 24);
+  const ciphertext = wire.slice(24);
+  const opened = nacl.box.open(
+    ciphertext,
+    nonce,
+    new Uint8Array(Buffer.from(senderPublicKey, 'base64url')),
+    encrypter.secretKey,
+  );
+  if (!opened) throw new Error('Failed to decrypt transfer payload');
+  return JSON.parse(Buffer.from(opened).toString('utf8')) as TransferResponse;
+}
+
+/**
+ * Run the browser-login transfer flow: generate an ephemeral NaCl keypair,
+ * open the Access login page, then long-poll the transfer service for the
+ * encrypted token and decrypt it. Mirrors `token.RunTransfer`.
+ */
+async function runTransfer(appURL: URL, appAUD: string): Promise<string> {
+  const keypair = nacl.box.keyPair();
+  const publicKey = base64url(keypair.publicKey);
+
+  const loginURL = buildLoginURL(appURL, appAUD, publicKey);
+  const transferURL = `${TRANSFER_STORE_URL}transfer/${publicKey}`;
+
+  console.error(`${color.info} Opening your browser to log in to ${color.path(appURL.origin)}`);
+  console.error(`${color.info} If it doesn't open, visit this URL manually:\n\n  ${loginURL}\n`);
+  await open(loginURL).catch(() => {
+    /* best effort — message above tells them how to open it manually */
+  });
+
+  for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+    const resp = await pollTransfer(transferURL, keypair);
+    if (resp?.app_token) {
+      return resp.app_token;
+    }
+    console.error(`${color.info} Waiting for you to finish logging in...`);
+  }
+  throw new Error('Timed out waiting for Cloudflare Access login to complete');
+}
+
+/**
+ * Return a valid Cloudflare Access application token for `appURL`, either from
+ * the on-disk cache or by running the interactive browser-login flow. The
+ * token is sent to the service in the `Cf-Access-Token` header.
+ */
+export async function getAccessToken(
+  appURL: URL,
+  opts: { forceRefresh?: boolean } = {},
+): Promise<string> {
+  const appInfo = await getAppInfo(appURL);
+
+  if (!opts.forceRefresh) {
+    const cached = readCachedToken(appInfo);
+    if (cached) {
+      d('using cached Access token for %s', appInfo.appDomain);
+      return cached;
+    }
+  }
+
+  const token = await runTransfer(appURL, appInfo.appAUD);
+  writeCachedToken(appInfo, token);
+  console.error(`${color.success} Authenticated with Cloudflare Access`);
+  return token;
+}
+
+/** Drop any cached token for `appURL` (used after a 401 to force re-login). */
+export async function clearCachedToken(appURL: URL): Promise<void> {
+  try {
+    const appInfo = await getAppInfo(appURL);
+    fs.rmSync(appTokenPath(appInfo), { force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+/**
+ * True when `res` is Cloudflare Access turning us away (expired/invalid token)
+ * rather than a legitimate application response. That's either a 401 from the
+ * origin or an edge redirect to the Access login page — as distinct from, say,
+ * the artifact-download endpoint's 302 to a signed blob URL.
+ */
+export function isAccessChallenge(res: Response): boolean {
+  if (res.status === 401) return true;
+  if (res.status >= 300 && res.status < 400) {
+    const location = res.headers.get('location') ?? '';
+    return (
+      location.includes('.cloudflareaccess.com') || location.includes(ACCESS_LOGIN_WORKER_PATH)
+    );
+  }
+  return false;
+}
+
+/**
+ * A thin fetch wrapper that attaches the Access token and, on an Access
+ * challenge, transparently re-authenticates once and retries. Redirects are
+ * surfaced to the caller (`redirect: 'manual'`) so legitimate ones — like the
+ * artifact download's 302 to signed storage — can be handled explicitly.
+ */
+export class AccessClient {
+  private constructor(
+    private readonly appURL: URL,
+    private token: string,
+  ) {}
+
+  static async create(appURL: URL): Promise<AccessClient> {
+    return new AccessClient(appURL, await getAccessToken(appURL));
+  }
+
+  async request(pathOrUrl: string, init: RequestInit = {}): Promise<Response> {
+    const url = /^https?:\/\//.test(pathOrUrl)
+      ? pathOrUrl
+      : new URL(pathOrUrl, this.appURL).toString();
+
+    const send = () =>
+      fetch(url, {
+        redirect: 'manual',
+        ...init,
+        headers: {
+          ...init.headers,
+          'User-Agent': USER_AGENT,
+          [CF_ACCESS_TOKEN_HEADER]: this.token,
+        },
+      });
+
+    let res = await send();
+    if (isAccessChallenge(res)) {
+      d('Access challenge on %s; refreshing token', url);
+      this.token = await getAccessToken(this.appURL, { forceRefresh: true });
+      res = await send();
+    }
+    return res;
+  }
+}

--- a/src/utils/cf-access.ts
+++ b/src/utils/cf-access.ts
@@ -183,16 +183,18 @@ async function pollTransfer(
   url: string,
   encrypter: { secretKey: Uint8Array },
 ): Promise<TransferResponse | null> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), POLL_TIMEOUT_MS);
   let res: Response;
   try {
     res = await fetch(url, {
       headers: { 'User-Agent': USER_AGENT },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(POLL_TIMEOUT_MS),
     });
-  } finally {
-    clearTimeout(timer);
+  } catch (err) {
+    // A per-poll timeout just means this long-poll didn't resolve in time —
+    // treat it as "not ready" so runTransfer starts another attempt rather
+    // than crashing the whole flow with an unhandled abort.
+    if (err instanceof DOMException && err.name === 'TimeoutError') return null;
+    throw err;
   }
 
   if (res.status >= 500) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,6 +1520,7 @@ __metadata:
     progress: "npm:^2.0.3"
     readline-sync: "npm:^1.4.10"
     semver: "npm:^7.6.0"
+    tweetnacl: "npm:^1.0.3"
     typescript: "npm:^6.0.0"
     vitest: "npm:~4.1.2"
     yaml: "npm:^2.8.3"
@@ -5673,6 +5674,13 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"tweetnacl@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "tweetnacl@npm:1.0.3"
+  checksum: 10c0/069d9df51e8ad4a89fbe6f9806c68e06c65be3c7d42f0701cc43dba5f0d6064686b238bbff206c5addef8854e3ce00c643bff59432ea2f2c639feab0ee1a93f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> Depends on electron/agent-workflows#11 (**merged**), which roots the roll
> bundle at a fetchable base commit. Without that, the bundle's base is a
> local-only commit and `apply` fails with `Repository lacks these
> prerequisite commits`.

## What

Adds `e auto-roll` — list the Chromium auto-rolls produced by the
[agent-workflows][aw] service, pick one interactively, download its git bundle,
and apply the proposed commits on top of your local `roller/chromium/main`.

```
e auto-roll [--branch <name>] [--remote <name>] [--no-fetch] [--limit <n>] [--run <id>] [--no-apply]
```

- Authenticates with the service's Cloudflare Access (browser SSO the first
  time; token cached under `~/.cloudflared`, reused after).
- Lists recent successful runs, shows the agent's summary + `base → head`, and
  asks before doing anything.
- Fetches the latest roller branch, then applies the roll: fast-forward when the
  branch is exactly at the roll's base, otherwise cherry-picks the commits on
  top. Conflicts stop with the bundle ref left at `refs/auto-roll/<run>` so you
  can resolve and `git cherry-pick --continue`.

## How the Cloudflare Access auth works (no `cloudflared` dependency)

`src/utils/cf-access.ts` ports cloudflared's browser-login token-transfer flow:
discover the Access app via the login redirect, open the login URL, long-poll
`login.cloudflareaccess.org` for the encrypted token, and decrypt it (NaCl box,
via `tweetnacl`). The token is sent in the `Cf-Access-Token` header, and cached
in `~/.cloudflared` so it interops with the real binary if present.

## Notes

- New dependency: `tweetnacl` (audited, zero-dep, no install scripts) for the
  NaCl box decryption — Node's `crypto` has X25519 but not XSalsa20/Poly1305.
- `git`-level apply mechanics (bundle verify, fetch-by-sha, fast-forward vs
  cherry-pick) were validated against synthetic repos locally.

[aw]: https://github.com/electron/agent-workflows
