### PR TITLE
feat: e download-dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains helper/wrapper scripts to make building Electron easier
 - [Core workflow](#core-workflow): [`init`](#e-init) · [`sync`](#e-sync) · [`build`](#e-build)
 - [Running Electron](#running-electron): [`start`](#e-start) · [`node`](#e-node) · [`debug`](#e-debug) · [`test`](#e-test) · [`npm`](#e-npm)
 - [Inspecting state](#inspecting-state): [`show`](#e-show) · [`shell`](#e-shell)
-- [Working with code](#working-with-code): [`patches`](#e-patches) · [`open`](#e-open) · [`pr`](#e-pr) · [`backport`](#e-backport) · [`cherry-pick`](#e-cherry-pick) · [`rcv`](#e-rcv)
+- [Working with code](#working-with-code): [`patches`](#e-patches) · [`open`](#e-open) · [`pr`](#e-pr) · [`download-dist`](#e-download-dist) · [`backport`](#e-backport) · [`cherry-pick`](#e-cherry-pick) · [`rcv`](#e-rcv)
 - [Managing configs](#managing-configs): [`use`](#e-use) · [`remove`](#e-remove) · [`sanitize-config`](#e-sanitize-config) · [`worktree`](#e-worktree) · [`load-macos-sdk`](#e-load-macos-sdk)
 - [Infrastructure](#infrastructure): [`depot-tools`](#e-depot-tools) · [`gh-auth`](#e-gh-auth) · [`auto-update`](#e-auto-update)
 - [Configuration file reference](#configuration-file-reference)
@@ -419,16 +419,28 @@ Work with pull requests to `electron/electron`.
 | `-t, --target <branch>`    | Target branch (default: guessed from the Electron version in your checkout)         |
 | `-b, --backport <pr#>`     | Pre-fill the PR body with notes and title from the original PR being backported     |
 
-**`e pr download-dist` options**
+Requires a GitHub token — see [`e gh-auth`](#e-gh-auth).
+
+### `e download-dist`
+
+Download the built `dist.zip` artifact from the latest `Build` workflow run on `electron/electron`,
+for either a pull request or a commit SHA.
+
+```sh
+$ e download-dist <pr-number-or-commit-sha>
+```
+
+**Options**
 
 | Option                     | Description                                                                                                 |
 |:---------------------------|:------------------------------------------------------------------------------------------------------------|
 | `--platform <platform>`    | Platform to download (default: current)                                                                     |
 | `--arch <arch>`            | Architecture (default: current)                                                                             |
-| `-o, --output <dir>`       | Artifact output directory (default: `~/.electron_build_tools/artifacts/pr_{number}_{hash}_{platform}_{arch}`) |
-| `-s, --skip-confirmation`  | Skip the confirmation prompt (enabled automatically in CI)                                                  |
+| `-o, --output <dir>`       | Output directory (default: `~/.electron_build_tools/artifacts/pr_{number}_{hash}_{platform}_{arch}` or `commit_{hash}_{platform}_{arch}`) |
+| `-s, --skip-confirmation`  | Skip the PR confirmation prompt (enabled automatically in CI)                                                                            |
 
 `e pr download-dist` requires a GitHub token — see [`e gh-auth`](#e-gh-auth).
+`e pr download-dist` an alias of `e download-dist` for backwards compatibility.
 
 ### `e backport`
 

--- a/src/e-download-dist.ts
+++ b/src/e-download-dist.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+
+import { downloadDist, DownloadDistOptions } from './utils/download-dist.js';
+
+const program = new Command();
+
+program
+  .argument('<pull_request_number_or_commit_sha>')
+  .description('Download a pull request or commit dist')
+  .option(
+    '--platform [platform]',
+    'Platform to download dist for. Defaults to current platform.',
+    process.platform,
+  )
+  .option(
+    '--arch [arch]',
+    'Architecture to download dist for. Defaults to current arch.',
+    process.arch,
+  )
+  .option(
+    '-o, --output <output_directory>',
+    'Specify the output directory for downloaded artifacts. ' +
+      'Defaults to ~/.electron_build_tools/artifacts/pr_{number}_{commithash}_{platform}_{arch} ' +
+      'or ~/.electron_build_tools/artifacts/commit_{sha}_{platform}_{arch}',
+  )
+  .option(
+    '-s, --skip-confirmation',
+    'Skip the confirmation prompt before downloading the dist.',
+    !!process.env['CI'],
+  )
+  .action(async (source: string, options: DownloadDistOptions) => {
+    await downloadDist(source, options);
+  })
+  .parse(process.argv);

--- a/src/e-pr.ts
+++ b/src/e-pr.ts
@@ -1,30 +1,18 @@
 #!/usr/bin/env node
 
 import * as childProcess from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import * as querystring from 'node:querystring';
 
-import extractZip from 'extract-zip';
 import * as semver from 'semver';
 import { Command } from 'commander';
-import * as inquirer from '@inquirer/prompts';
-import { Octokit } from '@octokit/rest';
-
-import debug from 'debug';
 
 const program = new Command();
-import { progressStream } from './utils/download.js';
-import { getGitHubAuthToken } from './utils/github-auth.js';
 import open from 'open';
 import { current } from './evm-config.js';
-import { color, fatal, logError } from './utils/logging.js';
+import { downloadDist, DownloadDistOptions } from './utils/download-dist.js';
+import { color, fatal } from './utils/logging.js';
 import type { SanitizedConfig } from './types.js';
-
-const d = debug('build-tools:pr');
 
 // Adapted from https://github.com/electron/clerk
 export function findNoteInPRBody(body: string): string | null {
@@ -199,13 +187,6 @@ program
     await open(`${repoBaseUrl}/compare/${comparePath}?${querystring.stringify(queryParams)}`);
   });
 
-interface DownloadDistOptions {
-  platform: string;
-  arch: string;
-  output?: string;
-  skipConfirmation: boolean;
-}
-
 program
   .command('download-dist <pull_request_number>')
   .description('Download a pull request dist')
@@ -234,207 +215,7 @@ program
       fatal(`Pull request number is required to download a PR`);
     }
 
-    d('checking auth...');
-    const auth = await getGitHubAuthToken(['repo']);
-    const octokit = new Octokit({ auth });
-
-    d('fetching pr info...');
-    let pullRequest;
-    try {
-      const { data } = await octokit.pulls.get({
-        owner: 'electron',
-        repo: 'electron',
-        pull_number: parseInt(pullRequestNumber, 10),
-      });
-      pullRequest = data;
-    } catch (error) {
-      console.error(`Failed to get pull request: ${String(error)}`);
-      return;
-    }
-
-    if (!options.skipConfirmation) {
-      const isElectronRepo = pullRequest.head.repo?.full_name !== 'electron/electron';
-      const proceed = await inquirer.confirm({
-        default: false,
-        message: `You are about to download artifacts from:
-
-“${pullRequest.title} (#${pullRequest.number})” by ${pullRequest.user?.login}
-${pullRequest.head.repo?.html_url}${isElectronRepo ? ' (fork)' : ''}
-${pullRequest.state !== 'open' ? '\n❗❗❗ The pull request is closed, only proceed if you trust the source ❗❗❗\n' : ''}
-Proceed?`,
-      });
-
-      if (!proceed) return;
-    }
-
-    d('fetching workflow runs...');
-    let workflowRuns;
-    try {
-      const { data } = await octokit.actions.listWorkflowRunsForRepo({
-        owner: 'electron',
-        repo: 'electron',
-        branch: pullRequest.head.ref,
-        event: 'pull_request',
-        status: 'completed',
-        per_page: 10,
-        // GitHub supports filtering by workflow name here but @octokit/openapi-types
-        // doesn't declare it. Without this filter, a PR with many concurrent
-        // workflows can push the Build run out of the first page of results.
-        name: 'Build',
-      } as Parameters<typeof octokit.actions.listWorkflowRunsForRepo>[0] & { name: string });
-      workflowRuns = data.workflow_runs;
-    } catch (error) {
-      console.error(`Failed to list workflow runs: ${String(error)}`);
-      return;
-    }
-
-    const latestBuildWorkflowRun = workflowRuns.find((run) => run.name === 'Build');
-    if (!latestBuildWorkflowRun) {
-      fatal(`No 'Build' workflow runs found for pull request #${pullRequestNumber}`);
-    }
-    const shortCommitHash = latestBuildWorkflowRun.head_sha.substring(0, 7);
-
-    d('fetching artifacts...');
-    let artifacts;
-    try {
-      const { data } = await octokit.actions.listWorkflowRunArtifacts({
-        owner: 'electron',
-        repo: 'electron',
-        run_id: latestBuildWorkflowRun.id,
-      });
-      artifacts = data.artifacts;
-    } catch (error) {
-      console.error(`Failed to list artifacts: ${String(error)}`);
-      return;
-    }
-
-    const artifactPlatform = options.platform === 'win32' ? 'win' : options.platform;
-    const artifactName = `generated_artifacts_${artifactPlatform}_${options.arch}`;
-    const artifact = artifacts.find((a) => a.name === artifactName);
-    if (!artifact) {
-      console.error(`Failed to find artifact: ${artifactName}`);
-      return;
-    }
-
-    let outputDir: string;
-
-    if (options.output) {
-      outputDir = path.resolve(options.output);
-
-      if (!(await fs.promises.stat(outputDir).catch(() => false))) {
-        fatal(`The output directory '${options.output}' does not exist`);
-      }
-    } else {
-      const artifactsDir = path.resolve(import.meta.dirname, '..', 'artifacts');
-      const defaultDir = path.resolve(
-        artifactsDir,
-        `pr_${pullRequest.number}_${shortCommitHash}_${options.platform}_${options.arch}`,
-      );
-
-      // Clean up the directory if it exists
-      try {
-        await fs.promises.rm(defaultDir, { recursive: true, force: true });
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          throw error;
-        }
-      }
-
-      // Create the directory
-      await fs.promises.mkdir(defaultDir, { recursive: true });
-
-      outputDir = defaultDir;
-    }
-
-    console.log(
-      `Downloading artifact '${artifactName}' from pull request #${pullRequestNumber}...`,
-    );
-
-    // Download the artifact to a temporary directory
-    const tempDir = path.join(os.tmpdir(), 'electron-tmp');
-    await fs.promises.rm(tempDir, { recursive: true, force: true });
-    await fs.promises.mkdir(tempDir);
-
-    const { url } = octokit.actions.downloadArtifact.endpoint({
-      owner: 'electron',
-      repo: 'electron',
-      artifact_id: artifact.id,
-      archive_format: 'zip',
-    });
-
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${auth}`,
-      },
-    });
-
-    if (!response.ok) {
-      fatal(`Could not find artifact: ${url} got ${response.status}`);
-    }
-
-    if (!response.body) {
-      fatal('Artifact download returned no body');
-    }
-
-    const total = parseInt(response.headers.get('content-length') ?? '0', 10);
-    const artifactDownloadStream = Readable.fromWeb(response.body);
-
-    try {
-      const artifactZipPath = path.join(tempDir, `${artifactName}.zip`);
-      const artifactFileStream = fs.createWriteStream(artifactZipPath);
-      if (process.env['CI']) {
-        await pipeline(artifactDownloadStream, artifactFileStream);
-      } else {
-        await pipeline(
-          artifactDownloadStream,
-          progressStream(total, '[:bar] :mbRateMB/s :percent :etas'),
-          artifactFileStream,
-        );
-      }
-
-      // Extract artifact zip
-      d('unzipping artifact to %s', tempDir);
-      await extractZip(artifactZipPath, { dir: tempDir });
-
-      // Check if dist.zip exists within the extracted artifact
-      const distZipPath = path.join(tempDir, 'dist.zip');
-      if (!(await fs.promises.stat(distZipPath).catch(() => false))) {
-        throw new Error(`dist.zip not found in build artifact.`);
-      }
-
-      // Extract dist.zip
-      // NOTE: 'extract-zip' is used as it correctly extracts symlinks.
-      d('unzipping dist.zip to %s', outputDir);
-      await extractZip(distZipPath, { dir: outputDir });
-
-      const platformExecutables: Record<string, string> = {
-        win32: 'electron.exe',
-        darwin: 'Electron.app/',
-        linux: 'electron',
-      };
-
-      const executableName = platformExecutables[options.platform];
-      if (!executableName) {
-        throw new Error(`Unable to find executable for platform '${options.platform}'`);
-      }
-
-      const executablePath = path.join(outputDir, executableName);
-      if (!(await fs.promises.stat(executablePath).catch(() => false))) {
-        throw new Error(`${executableName} not found within dist.zip.`);
-      }
-
-      console.log(`${color.success} Downloaded to ${outputDir}`);
-    } catch (error) {
-      logError(error);
-      process.exitCode = 1; // wait for cleanup
-    } finally {
-      // Cleanup temporary files
-      try {
-        await fs.promises.rm(tempDir, { recursive: true });
-      } catch {
-        // ignore
-      }
-    }
+    await downloadDist(pullRequestNumber, options);
   });
 
 if (import.meta.main) {

--- a/src/e.ts
+++ b/src/e.ts
@@ -214,6 +214,10 @@ program
   .alias('auto-cherry-pick')
   .command('gh-auth', 'Generates a device oauth token')
   .command(
+    'download-dist <pull_request_number_or_commit_sha>',
+    'Download a pull request or commit dist',
+  )
+  .command(
     'rcv <roll-pr> [chromium-version]',
     'Attempts to reconstruct an intermediate Chromium version from a roll PR',
   )

--- a/src/utils/download-dist.ts
+++ b/src/utils/download-dist.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { styleText } from 'node:util';
 
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -23,36 +24,71 @@ export interface DownloadDistOptions {
   skipConfirmation: boolean;
 }
 
-export async function downloadDist(
-  pullRequestNumber: string,
-  options: DownloadDistOptions,
-): Promise<void> {
+export async function downloadDist(source: string, options: DownloadDistOptions): Promise<void> {
   d('checking auth...');
   const auth = await getGitHubAuthToken(['repo']);
   const octokit = new Octokit({ auth });
 
-  d('fetching pr info...');
   let pullRequest;
-  try {
-    const { data } = await octokit.pulls.get({
-      owner: 'electron',
-      repo: 'electron',
-      pull_number: parseInt(pullRequestNumber, 10),
-    });
-    pullRequest = data;
-  } catch (error) {
-    console.error(`Failed to get pull request: ${String(error)}`);
-    return;
+
+  if (/^.*[a-zA-Z].*$/.test(source)) {
+    // Looks like a commit SHA, so try to look it up
+    d('fetching commit info...');
+    try {
+      const { data } = await octokit.repos.getCommit({
+        owner: 'electron',
+        repo: 'electron',
+        ref: source,
+      });
+      source = data.sha;
+    } catch (error) {
+      fatal(`Failed to get commit ${styleText('yellow', source)}:\n${String(error)}`);
+    }
+  } else {
+    // Still could be a commit SHA, with no letters
+    let commitFound = false;
+
+    if (source.length >= 7) {
+      d('fetching commit info...');
+      try {
+        const { data } = await octokit.repos.getCommit({
+          owner: 'electron',
+          repo: 'electron',
+          ref: source,
+        });
+        source = data.sha;
+        commitFound = true;
+      } catch (error: any) {
+        if (error?.status !== 404) {
+          fatal(`Failed to get commit ${styleText('yellow', source)}:\n${String(error)}`);
+        }
+      }
+    }
+
+    // Check if it's a pull request number
+    if (!commitFound) {
+      d('fetching pr info...');
+      try {
+        const { data } = await octokit.pulls.get({
+          owner: 'electron',
+          repo: 'electron',
+          pull_number: parseInt(source, 10),
+        });
+        pullRequest = data;
+      } catch (error: any) {
+        fatal(`Failed to get pull request ${styleText('yellow', source)}:\n${String(error)}`);
+      }
+    }
   }
 
-  if (!options.skipConfirmation) {
-    const isElectronRepo = pullRequest.head.repo?.full_name !== 'electron/electron';
+  if (pullRequest && !options.skipConfirmation) {
+    const isElectronRepo = pullRequest.head.repo?.full_name === 'electron/electron';
     const proceed = await inquirer.confirm({
       default: false,
       message: `You are about to download artifacts from:
 
 “${pullRequest.title} (#${pullRequest.number})” by ${pullRequest.user?.login}
-${pullRequest.head.repo?.html_url}${isElectronRepo ? ' (fork)' : ''}
+${pullRequest.head.repo?.html_url}${isElectronRepo ? '' : ' (fork)'}
 ${pullRequest.state !== 'open' ? '\n❗❗❗ The pull request is closed, only proceed if you trust the source ❗❗❗\n' : ''}
 Proceed?`,
     });
@@ -66,8 +102,15 @@ Proceed?`,
     const { data } = await octokit.actions.listWorkflowRunsForRepo({
       owner: 'electron',
       repo: 'electron',
-      branch: pullRequest.head.ref,
-      event: 'pull_request',
+      ...(pullRequest
+        ? {
+            branch: pullRequest.head.ref,
+            event: 'pull_request',
+          }
+        : {
+            head_sha: source,
+            event: 'push',
+          }),
       status: 'completed',
       per_page: 10,
       // GitHub supports filtering by workflow name here but @octokit/openapi-types
@@ -83,7 +126,11 @@ Proceed?`,
 
   const latestBuildWorkflowRun = workflowRuns.find((run) => run.name === 'Build');
   if (!latestBuildWorkflowRun) {
-    fatal(`No 'Build' workflow runs found for pull request #${pullRequestNumber}`);
+    if (pullRequest) {
+      fatal(`No 'Build' workflow runs found for pull request #${pullRequest.number}`);
+    } else {
+      fatal(`No 'Build' workflow runs found for commit ${styleText('yellow', source)}`);
+    }
   }
   const shortCommitHash = latestBuildWorkflowRun.head_sha.substring(0, 7);
 
@@ -118,10 +165,12 @@ Proceed?`,
       fatal(`The output directory '${options.output}' does not exist`);
     }
   } else {
-    const artifactsDir = path.resolve(import.meta.dirname, '..', 'artifacts');
+    const artifactsDir = path.resolve(import.meta.dirname, '..', '..', 'artifacts');
     const defaultDir = path.resolve(
       artifactsDir,
-      `pr_${pullRequest.number}_${shortCommitHash}_${options.platform}_${options.arch}`,
+      pullRequest
+        ? `pr_${pullRequest.number}_${shortCommitHash}_${options.platform}_${options.arch}`
+        : `commit_${source}_${options.platform}_${options.arch}`,
     );
 
     // Clean up the directory if it exists
@@ -139,7 +188,15 @@ Proceed?`,
     outputDir = defaultDir;
   }
 
-  console.log(`Downloading artifact '${artifactName}' from pull request #${pullRequestNumber}...`);
+  if (pullRequest) {
+    console.log(
+      `Downloading artifact '${artifactName}' from pull request ${styleText('green', '#' + pullRequest.number)}...`,
+    );
+  } else {
+    console.log(
+      `Downloading artifact '${artifactName}' from commit ${styleText('green', source)}...`,
+    );
+  }
 
   // Download the artifact to a temporary directory
   const tempDir = path.join(os.tmpdir(), 'electron-tmp');

--- a/src/utils/download-dist.ts
+++ b/src/utils/download-dist.ts
@@ -1,0 +1,229 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+import * as inquirer from '@inquirer/prompts';
+import { Octokit } from '@octokit/rest';
+import debug from 'debug';
+import extractZip from 'extract-zip';
+
+import { progressStream } from './download.js';
+import { getGitHubAuthToken } from './github-auth.js';
+import { color, fatal, logError } from './logging.js';
+
+const d = debug('build-tools:download-dist');
+
+export interface DownloadDistOptions {
+  platform: string;
+  arch: string;
+  output?: string;
+  skipConfirmation: boolean;
+}
+
+export async function downloadDist(
+  pullRequestNumber: string,
+  options: DownloadDistOptions,
+): Promise<void> {
+  d('checking auth...');
+  const auth = await getGitHubAuthToken(['repo']);
+  const octokit = new Octokit({ auth });
+
+  d('fetching pr info...');
+  let pullRequest;
+  try {
+    const { data } = await octokit.pulls.get({
+      owner: 'electron',
+      repo: 'electron',
+      pull_number: parseInt(pullRequestNumber, 10),
+    });
+    pullRequest = data;
+  } catch (error) {
+    console.error(`Failed to get pull request: ${String(error)}`);
+    return;
+  }
+
+  if (!options.skipConfirmation) {
+    const isElectronRepo = pullRequest.head.repo?.full_name !== 'electron/electron';
+    const proceed = await inquirer.confirm({
+      default: false,
+      message: `You are about to download artifacts from:
+
+“${pullRequest.title} (#${pullRequest.number})” by ${pullRequest.user?.login}
+${pullRequest.head.repo?.html_url}${isElectronRepo ? ' (fork)' : ''}
+${pullRequest.state !== 'open' ? '\n❗❗❗ The pull request is closed, only proceed if you trust the source ❗❗❗\n' : ''}
+Proceed?`,
+    });
+
+    if (!proceed) return;
+  }
+
+  d('fetching workflow runs...');
+  let workflowRuns;
+  try {
+    const { data } = await octokit.actions.listWorkflowRunsForRepo({
+      owner: 'electron',
+      repo: 'electron',
+      branch: pullRequest.head.ref,
+      event: 'pull_request',
+      status: 'completed',
+      per_page: 10,
+      // GitHub supports filtering by workflow name here but @octokit/openapi-types
+      // doesn't declare it. Without this filter, a PR with many concurrent
+      // workflows can push the Build run out of the first page of results.
+      name: 'Build',
+    } as Parameters<typeof octokit.actions.listWorkflowRunsForRepo>[0] & { name: string });
+    workflowRuns = data.workflow_runs;
+  } catch (error) {
+    console.error(`Failed to list workflow runs: ${String(error)}`);
+    return;
+  }
+
+  const latestBuildWorkflowRun = workflowRuns.find((run) => run.name === 'Build');
+  if (!latestBuildWorkflowRun) {
+    fatal(`No 'Build' workflow runs found for pull request #${pullRequestNumber}`);
+  }
+  const shortCommitHash = latestBuildWorkflowRun.head_sha.substring(0, 7);
+
+  d('fetching artifacts...');
+  let artifacts;
+  try {
+    const { data } = await octokit.actions.listWorkflowRunArtifacts({
+      owner: 'electron',
+      repo: 'electron',
+      run_id: latestBuildWorkflowRun.id,
+    });
+    artifacts = data.artifacts;
+  } catch (error) {
+    console.error(`Failed to list artifacts: ${String(error)}`);
+    return;
+  }
+
+  const artifactPlatform = options.platform === 'win32' ? 'win' : options.platform;
+  const artifactName = `generated_artifacts_${artifactPlatform}_${options.arch}`;
+  const artifact = artifacts.find((a) => a.name === artifactName);
+  if (!artifact) {
+    console.error(`Failed to find artifact: ${artifactName}`);
+    return;
+  }
+
+  let outputDir: string;
+
+  if (options.output) {
+    outputDir = path.resolve(options.output);
+
+    if (!(await fs.promises.stat(outputDir).catch(() => false))) {
+      fatal(`The output directory '${options.output}' does not exist`);
+    }
+  } else {
+    const artifactsDir = path.resolve(import.meta.dirname, '..', 'artifacts');
+    const defaultDir = path.resolve(
+      artifactsDir,
+      `pr_${pullRequest.number}_${shortCommitHash}_${options.platform}_${options.arch}`,
+    );
+
+    // Clean up the directory if it exists
+    try {
+      await fs.promises.rm(defaultDir, { recursive: true, force: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    // Create the directory
+    await fs.promises.mkdir(defaultDir, { recursive: true });
+
+    outputDir = defaultDir;
+  }
+
+  console.log(`Downloading artifact '${artifactName}' from pull request #${pullRequestNumber}...`);
+
+  // Download the artifact to a temporary directory
+  const tempDir = path.join(os.tmpdir(), 'electron-tmp');
+  await fs.promises.rm(tempDir, { recursive: true, force: true });
+  await fs.promises.mkdir(tempDir);
+
+  const { url } = octokit.actions.downloadArtifact.endpoint({
+    owner: 'electron',
+    repo: 'electron',
+    artifact_id: artifact.id,
+    archive_format: 'zip',
+  });
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${auth}`,
+    },
+  });
+
+  if (!response.ok) {
+    fatal(`Could not find artifact: ${url} got ${response.status}`);
+  }
+
+  if (!response.body) {
+    fatal('Artifact download returned no body');
+  }
+
+  const total = parseInt(response.headers.get('content-length') ?? '0', 10);
+  const artifactDownloadStream = Readable.fromWeb(response.body);
+
+  try {
+    const artifactZipPath = path.join(tempDir, `${artifactName}.zip`);
+    const artifactFileStream = fs.createWriteStream(artifactZipPath);
+    if (process.env['CI']) {
+      await pipeline(artifactDownloadStream, artifactFileStream);
+    } else {
+      await pipeline(
+        artifactDownloadStream,
+        progressStream(total, '[:bar] :mbRateMB/s :percent :etas'),
+        artifactFileStream,
+      );
+    }
+
+    // Extract artifact zip
+    d('unzipping artifact to %s', tempDir);
+    await extractZip(artifactZipPath, { dir: tempDir });
+
+    // Check if dist.zip exists within the extracted artifact
+    const distZipPath = path.join(tempDir, 'dist.zip');
+    if (!(await fs.promises.stat(distZipPath).catch(() => false))) {
+      throw new Error(`dist.zip not found in build artifact.`);
+    }
+
+    // Extract dist.zip
+    // NOTE: 'extract-zip' is used as it correctly extracts symlinks.
+    d('unzipping dist.zip to %s', outputDir);
+    await extractZip(distZipPath, { dir: outputDir });
+
+    const platformExecutables: Record<string, string> = {
+      win32: 'electron.exe',
+      darwin: 'Electron.app/',
+      linux: 'electron',
+    };
+
+    const executableName = platformExecutables[options.platform];
+    if (!executableName) {
+      throw new Error(`Unable to find executable for platform '${options.platform}'`);
+    }
+
+    const executablePath = path.join(outputDir, executableName);
+    if (!(await fs.promises.stat(executablePath).catch(() => false))) {
+      throw new Error(`${executableName} not found within dist.zip.`);
+    }
+
+    console.log(`${color.success} Downloaded to ${outputDir}`);
+  } catch (error) {
+    logError(error);
+    process.exitCode = 1; // wait for cleanup
+  } finally {
+    // Cleanup temporary files
+    try {
+      await fs.promises.rm(tempDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
Promotes `e pr download-dist` to top-level `e download-dist` and lets it take either a PR number or a commit SHA. This makes it easy to download the dist for any given commit in `e/e` (assuming artifacts haven't expired) which is useful for quickly bisecting the individual commits on a nightly.