### PR TITLE
feat: e start --from-dist option

### DIFF
--- a/src/e.ts
+++ b/src/e.ts
@@ -8,6 +8,7 @@ import { program } from 'commander';
 
 import * as evmConfig from './evm-config.js';
 import { color, fatal } from './utils/logging.js';
+import { downloadDist } from './utils/download-dist.js';
 import * as depot from './utils/depot-tools.js';
 import { ensurePrereqs } from './utils/prereqs.js';
 import { refreshPathVariable } from './utils/refresh-path.js';
@@ -121,9 +122,27 @@ program
   .alias('run')
   .description('Run the Electron executable')
   .allowUnknownOption()
-  .action((args: string[]) => {
+  .option(
+    '--from-dist <pull_request_number_or_commit_sha>',
+    'Download the dist for the given PR number or commit SHA and run it instead of the local build',
+  )
+  .action(async (args: string[], options: { fromDist?: string }) => {
     try {
-      const exec = evmConfig.execOf(evmConfig.current());
+      let exec: string;
+
+      if (options.fromDist) {
+        const downloadedExec = await downloadDist(options.fromDist, {
+          platform: process.platform,
+          arch: process.arch,
+        });
+        if (!downloadedExec) {
+          fatal(`Failed to download dist for ${color.path(options.fromDist)}`);
+        }
+        exec = downloadedExec;
+      } else {
+        exec = evmConfig.execOf(evmConfig.current());
+      }
+
       if (!fs.existsSync(exec)) {
         fatal(`Could not find Electron executable at ${color.path(exec)}`);
       }
@@ -142,6 +161,8 @@ program
     console.log('  $ e start .');
     console.log('  $ e start /path/to/app');
     console.log('  $ e start /path/to/app --js-flags');
+    console.log('  $ e start --from-dist 12345 .');
+    console.log('  $ e start --from-dist <commit-sha> .');
   });
 
 program

--- a/src/utils/download-dist.ts
+++ b/src/utils/download-dist.ts
@@ -21,10 +21,33 @@ export interface DownloadDistOptions {
   platform: string;
   arch: string;
   output?: string;
-  skipConfirmation: boolean;
+  skipConfirmation?: boolean;
 }
 
-export async function downloadDist(source: string, options: DownloadDistOptions): Promise<void> {
+export async function getDistExecutablePath(outputDir: string, platform: string): Promise<string> {
+  const platformExecutables: Record<string, string> = {
+    win32: 'electron.exe',
+    darwin: path.join('Electron.app', 'Contents', 'MacOS', 'Electron'),
+    linux: 'electron',
+  };
+
+  const executableName = platformExecutables[platform];
+  if (!executableName) {
+    throw new Error(`Unable to find executable for platform '${platform}'`);
+  }
+
+  const executablePath = path.join(outputDir, executableName);
+  if (!(await fs.promises.stat(executablePath).catch(() => false))) {
+    throw new Error(`${executableName} not found within dist.zip.`);
+  }
+
+  return executablePath;
+}
+
+export async function downloadDist(
+  source: string,
+  options: DownloadDistOptions,
+): Promise<string | undefined> {
   d('checking auth...');
   const auth = await getGitHubAuthToken(['repo']);
   const octokit = new Octokit({ auth });
@@ -255,26 +278,14 @@ Proceed?`,
     d('unzipping dist.zip to %s', outputDir);
     await extractZip(distZipPath, { dir: outputDir });
 
-    const platformExecutables: Record<string, string> = {
-      win32: 'electron.exe',
-      darwin: 'Electron.app/',
-      linux: 'electron',
-    };
-
-    const executableName = platformExecutables[options.platform];
-    if (!executableName) {
-      throw new Error(`Unable to find executable for platform '${options.platform}'`);
-    }
-
-    const executablePath = path.join(outputDir, executableName);
-    if (!(await fs.promises.stat(executablePath).catch(() => false))) {
-      throw new Error(`${executableName} not found within dist.zip.`);
-    }
-
+    const executablePath = await getDistExecutablePath(outputDir, options.platform);
     console.log(`${color.success} Downloaded to ${outputDir}`);
+
+    return executablePath;
   } catch (error) {
     logError(error);
     process.exitCode = 1; // wait for cleanup
+    return undefined;
   } finally {
     // Cleanup temporary files
     try {


### PR DESCRIPTION
Leverages the same codepath as `e download-dist` to make it quicker for maintainers to start an executable from a PR to validate during code review.