### PR TITLE
chore: add win toolchain 3bfcb536c8

### DIFF
--- a/src/utils/depot-tools.ts
+++ b/src/utils/depot-tools.ts
@@ -97,6 +97,7 @@ function platformOpts(): Record<string, string> {
       GYP_MSVS_HASH_7393122652: '3ba76c5c20',
       GYP_MSVS_HASH_698eb5635a: 'e2bf90edff',
       GYP_MSVS_HASH_e4305f407e: 'efe71370d5',
+      GYP_MSVS_HASH_3bfcb536c8: '8254f4cd2f',
     };
   }
 


### PR DESCRIPTION
Adds a new toolchain [8088195: Update Win toolchain to SDK 10.0.28000.2270](https://chromium-review.googlesource.com/c/chromium/src/+/8088195); needed for https://github.com/electron/electron/pull/52567.