### PR TITLE
feat: run the mojom, Blink, grit and TypeScript generators remotely

### DIFF
--- a/tools/main.star
+++ b/tools/main.star
@@ -61,6 +61,25 @@ def init(ctx):
           "lld-link": step_config["platforms"]["default"],
       })
 
+    # Chromium gates remote execution of the mojom and Blink bindings
+    # generators on its "googlechrome" config; on Electron's RBE they run
+    # fine as-is (Linux workers with python3, all inputs checked in), so
+    # enable them for every host. Validated on rbe.notgoma.com:
+    # mojom_parser, mojom_bindings_generator, generate_type_mappings and
+    # blink/generate_bindings all produce byte-identical outputs remotely.
+    # Besides taking ~1 CPU-hour of python off the 5-core macOS runners
+    # per build, remote steps are cached, so unchanged generators become
+    # cache hits on every host instead of running locally each time.
+    for rule in step_config["rules"]:
+      if rule["name"] in (
+          "mojo/mojom_bindings_generator",
+          "mojo/mojom_parser",
+          "mojo/generate_type_mappings",
+          "blink/generate_bindings",
+      ):
+        rule["remote"] = True
+        rule["remote_command"] = "python3"
+
     return module(
       "config",
       step_config = json.encode(step_config),

--- a/tools/main.star
+++ b/tools/main.star
@@ -61,24 +61,38 @@ def init(ctx):
           "lld-link": step_config["platforms"]["default"],
       })
 
-    # Chromium gates remote execution of the mojom and Blink bindings
-    # generators on its "googlechrome" config; on Electron's RBE they run
-    # fine as-is (Linux workers with python3, all inputs checked in), so
-    # enable them for every host. Validated on rbe.notgoma.com:
-    # mojom_parser, mojom_bindings_generator, generate_type_mappings and
-    # blink/generate_bindings all produce byte-identical outputs remotely.
-    # Besides taking ~1 CPU-hour of python off the 5-core macOS runners
-    # per build, remote steps are cached, so unchanged generators become
-    # cache hits on every host instead of running locally each time.
+    # Chromium gates remote execution of its python/node code generators
+    # (mojom, Blink bindings, grit strings, TypeScript/WebUI) on its
+    # "googlechrome" config; on Electron's RBE they run fine as-is (Linux
+    # workers with python3/node, all inputs checked in), so enable them for
+    # every host. Each of these was validated on rbe.notgoma.com: it executes
+    # remotely, produces byte-identical outputs and cache-hits on rerun.
+    # Besides taking ~1 CPU-hour of python off the 5-core macOS runners per
+    # build, remote steps are cached, so unchanged generators become cache
+    # hits on every host instead of running locally each time.
+    #
+    # The typescript/webui rules need their Starlark handlers (which add the
+    # node_modules etc. inputs); Chromium only attaches them when remote is
+    # enabled at config time, so attach them here.
+    remote_generators = {
+        "mojo/mojom_bindings_generator": None,
+        "mojo/mojom_parser": None,
+        "mojo/generate_type_mappings": None,
+        "blink/generate_bindings": None,
+        "grit/chrome_app_generated_resources": None,
+        "grit/components_strings": None,
+        "typescript/ts_library": "typescript_ts_library",
+        "webui/minify_js": None,
+        "webui/stylelint": None,
+        "webui/eslint_ts": "webui_eslint_ts",
+    }
     for rule in step_config["rules"]:
-      if rule["name"] in (
-          "mojo/mojom_bindings_generator",
-          "mojo/mojom_parser",
-          "mojo/generate_type_mappings",
-          "blink/generate_bindings",
-      ):
+      if rule["name"] in remote_generators:
         rule["remote"] = True
         rule["remote_command"] = "python3"
+        handler = remote_generators[rule["name"]]
+        if handler:
+          rule["handler"] = handler
 
     return module(
       "config",


### PR DESCRIPTION
Chromium gates remote execution of its python/node code generators on its `googlechrome` siso config. They run fine on Electron's RBE as-is (Linux workers with `python3`/node, every input checked in), so enable the validated set for every host:

* `mojo/mojom_parser`, `mojo/mojom_bindings_generator`, `mojo/generate_type_mappings`, `blink/generate_bindings`, `grit/chrome_app_generated_resources`, `grit/components_strings`, `typescript/ts_library`, `webui/minify_js`, `webui/stylelint`, `webui/eslint_ts`.
* Each was validated from a macOS host against `rbe.notgoma.com`: executes remotely (`Remote:N, LocalFallback:0`), produces byte-identical outputs to the local run, and cache-hits on rerun (`CacheHit:N`). The only local-vs-remote difference is the intermediate `.mojom-module` pickle's memo layout (Python version), semantically identical and irrelevant when everything runs remotely.
* Why: on the 5-core macOS CI runners these are ~1 CPU-hour of local python/node per release build (1,148 mojom generator steps; the Blink bindings generator drops from ~4 min local to ~30 s on a worker), contending with siso's include scanning during the fetch phase. And since remote steps are cached, unchanged generators become cache hits on every host instead of running locally each build.
* Not enabled: `typescript/ts_definitions` (matches nothing in our build), the Linux-host-only Blink `run_with_pythonpath`/`build_web_idl_database` rules, and the v8/rust/nasm/proto rules (run built binaries, so Linux hosts only; not validated).

Companion to electron/electron#52883 / #52884 (macOS release build time work).