### PR TITLE
feat: preflight the Metal toolchain before building on macOS

### DIFF
--- a/src/e-build.ts
+++ b/src/e-build.ts
@@ -10,6 +10,7 @@ import * as evmConfig from './evm-config.js';
 import { color, fatal } from './utils/logging.js';
 import * as depot from './utils/depot-tools.js';
 import { ensureDir } from './utils/paths.js';
+import { ensureMetalToolchain } from './utils/prereqs.js';
 import * as reclient from './utils/reclient.js';
 import * as siso from './utils/siso.js';
 import { ensureSDK, ensureSDKAndSymlink } from './utils/sdk.js';
@@ -98,6 +99,8 @@ async function runNinja(
   } else {
     console.info(`${color.info} Building ${target} with remote execution disabled`);
   }
+
+  ensureMetalToolchain();
 
   depot.ensure();
   await ensureGNGen(config, genMode);

--- a/src/utils/prereqs.ts
+++ b/src/utils/prereqs.ts
@@ -54,6 +54,44 @@ function checkNodeVersion(): boolean {
 }
 
 /**
+ * Check if the Metal toolchain is usable
+ *
+ * Xcode 26 unbundled the Metal toolchain into a separately installed component,
+ * but Xcode still ships a `metal` stub that fails at execution time when the
+ * component is missing - so probe by running the tool rather than looking for it.
+ * @returns {boolean} True if the Metal toolchain can be executed, false otherwise
+ */
+function checkMetalToolchain(): boolean {
+  try {
+    execSync('xcrun metal --version', {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure the Metal toolchain is installed, as ANGLE's shader targets need it.
+ * Only relevant on macOS, and only for builds - syncing does not use it.
+ */
+export function ensureMetalToolchain(): void {
+  if (process.platform !== 'darwin') return;
+
+  if (!checkMetalToolchain()) {
+    fatal(
+      `The Metal toolchain is not installed, and ANGLE's shader targets need it to build. ` +
+        `Xcode 26 unbundled it from Xcode itself, so it has to be installed separately:\n` +
+        `  xcodebuild -runFirstLaunch\n` +
+        `  xcodebuild -downloadComponent MetalToolchain`,
+    );
+  }
+}
+
+/**
  * Ensure system prereqs installed and meet minimum version requirements
  */
 export function ensurePrereqs(): void {

--- a/tests/prereqs.spec.mjs
+++ b/tests/prereqs.spec.mjs
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const modulePath = pathToFileURL(
+  path.join(import.meta.dirname, '..', 'dist', 'utils', 'prereqs.js'),
+).href;
+
+// `ensureMetalToolchain()` exits the process on failure, so run it in a child
+const runEnsureMetalToolchain = (env) =>
+  spawnSync(
+    process.execPath,
+    ['-e', `import('${modulePath}').then((m) => m.ensureMetalToolchain())`],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    },
+  );
+
+// Whether this machine can actually run the Metal compiler, which decides
+// which direction of the check is testable here
+const metalToolchainInstalled =
+  process.platform === 'darwin' &&
+  spawnSync('xcrun', ['metal', '--version'], { stdio: 'ignore' }).status === 0;
+
+describe('prereqs', () => {
+  describe('ensureMetalToolchain', () => {
+    it.skipIf(!metalToolchainInstalled)('passes when the Metal toolchain is installed', () => {
+      const result = runEnsureMetalToolchain({});
+
+      expect(result.status).toEqual(0);
+      expect(result.stderr).toEqual('');
+    });
+
+    it.skipIf(process.platform !== 'darwin')(
+      'fails with install instructions when the Metal toolchain is unavailable',
+      () => {
+        // No Xcode to find the toolchain in, which is what a missing component looks like
+        const result = runEnsureMetalToolchain({ DEVELOPER_DIR: '/nonexistent' });
+
+        expect(result.status).toEqual(1);
+        expect(result.stderr).toContain('xcodebuild -downloadComponent MetalToolchain');
+      },
+    );
+
+    it.skipIf(process.platform === 'darwin')('is a no-op off macOS', () => {
+      const result = runEnsureMetalToolchain({});
+
+      expect(result.status).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #780.

On a fresh macOS machine the first `e build` runs for a long while and then stops deep in ANGLE's
shader step:

```
error: error: cannot execute tool 'metal' due to missing Metal Toolchain;
use: xcodebuild -downloadComponent MetalToolchain
```

Xcode 26 unbundled the Metal toolchain into a separately installed component. electron/electron#48467
taught ANGLE to run `metal` / `metallib` through `xcrun` for system Xcode installs, but nothing
installs the component, so a fresh checkout still hits this. This checks for it before starting
ninja and names both commands the issue reporter needed:

```
  xcodebuild -runFirstLaunch
  xcodebuild -downloadComponent MetalToolchain
```

### On the detection method

The check runs `xcrun metal --version` rather than looking for the binary, because the obvious check
is misleading: `Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/metal`
exists even when the component is *not* installed – it is a stub that fails at execution time, while
the real toolchain lives on a cryptex mount
(`/var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain-*/Metal.xctoolchain`).
A path-existence check would therefore report success on exactly the machines that cannot build.

Naming `xcodebuild -runFirstLaunch` first also covers the neighbouring case where Xcode is installed
but its first launch has not been completed, which makes `xcrun` fail the same way.

### On the placement

It runs from `runNinja()` rather than `ensurePrereqs()`, which is called for every `e` command –
`e sync`, `e show` and friends do not need the Metal toolchain and should not be gated on it. It
also stays out of `--gen only`, which returns before `runNinja()` and never compiles a shader.

Happy to move it next to the existing `ensureSDK()` call in the command action if you would rather
it match that shape – that fails a little earlier, at the cost of gating `--gen only` too.

### On the scope

It gates every `e build`, including `-t <target>` builds that may never reach ANGLE. Scoping it to
the default target would not be reliable: `defaultTarget` is configurable per config, so the target
that needs the toolchain is not knowable without asking gn, which has not run at that point. As it
stands the check is still narrower than the existing prereqs – `ensurePrereqs()` fatals on Python
and Node for every `e` command, while this is macOS-only and build-only – and the remedy is a
one-time component install on a machine that already carries a Chromium checkout.

### Testing

* Positive path (toolchain installed): passes silently, and `e build` completes as before
* Negative path (`DEVELOPER_DIR=/nonexistent`): exits 1 with the install instructions
* Both directions are covered by specs, each skipped on the platform where it cannot hold –
  `npm test` passes (8 files, 93 passing, 1 skipped)
* `npm run lint:ts` clean
* Cost is one `xcrun` invocation per build: 0.01s warm, 0.38s cold

Disclosure: I developed this with Claude (Claude Code), and reviewed, built, and tested it locally.
