### PR TITLE
feat: run Electron's clang-tidy steps remotely

### DIFF
--- a/tools/main.star
+++ b/tools/main.star
@@ -105,6 +105,42 @@ def init(ctx):
         if handler:
           rule["handler"] = handler
 
+    # clang-tidy build steps from electron/script/gen-clang-tidy-ninja.py. They
+    # are shaped like compiles so scandeps finds their inputs, and are cached
+    # and executed remotely like compiles.
+    tidy_wrapper = "electron/build/run-clang-tidy-action.sh"
+    tidy_rule = {
+        "name": "electron/clang-tidy",
+        "action": "clang_tidy",
+        "command_prefix": "../../" + tidy_wrapper + " ",
+        "inputs": [
+            tidy_wrapper,
+            "third_party/llvm-build/Release+Asserts/bin/clang-tidy",
+            ".clang-tidy",
+            "electron/.clang-tidy",
+        ],
+        "exclude_input_patterns": ["*.stamp"],
+        "remote": True,
+        "timeout": "10m",
+    }
+    step_config["input_deps"][tidy_rule["inputs"][1]] = step_config["input_deps"].get(
+        "third_party/llvm-build/Release+Asserts/bin/clang++", [])
+    step_config.setdefault("executables", [])
+    step_config["executables"].extend(tidy_rule["inputs"][:2])
+    if runtime.os != "linux":
+      # Same arrangement as the clang rules above: the RBE workers are Linux, so
+      # run through clang_remote_wrapper with the Linux toolchain staged next to
+      # the host one. The clang-tidy job downloads the Linux clang-tidy there.
+      linux_tools = [
+          "buildtools/reclient_cfgs/chromium-browser-clang/clang_remote_wrapper",
+          "third_party/llvm-build/Release+Asserts_linux/bin/clang",
+          "third_party/llvm-build/Release+Asserts_linux/bin/clang-tidy",
+      ]
+      tidy_rule["remote_wrapper"] = "../../" + linux_tools[0]
+      tidy_rule["inputs"].extend(linux_tools)
+      step_config["executables"].extend(linux_tools)
+    step_config["rules"].insert(0, tidy_rule)
+
     return module(
       "config",
       step_config = json.encode(step_config),


### PR DESCRIPTION
Adds an `electron/clang-tidy` siso step rule for the per-translation-unit clang-tidy steps from electron/electron#53447. The steps are shaped like compiles, so siso include-scans them, caches them in the RBE action cache, and runs misses remotely.

- The rule only matches the `clang_tidy` action, so ordinary builds are unaffected.
- Off Linux it runs through `clang_remote_wrapper` with the Linux clang and clang-tidy, like the clang rules.

Validated on electron/electron#53447, which carries an identical copy of this file for now:

| leg | first run | rerun |
|---|---|---|
| linux-x64 | 342 steps, all remote | 342/342 cache hits |
| windows-x64 | 344 steps, all remote | 344/344 cache hits |
| macos-arm64 | 371 steps, all remote | 371/371 cache hits |

Once this lands, electron/electron#53447 bumps the build-tools pin and drops its copy.
