### PR TITLE
fix: send nested .clang-tidy configs with Electron's clang-tidy steps

### DIFF
--- a/tools/main.star
+++ b/tools/main.star
@@ -118,6 +118,9 @@ def init(ctx):
             "third_party/llvm-build/Release+Asserts/bin/clang-tidy",
             ".clang-tidy",
             "electron/.clang-tidy",
+            # clang-tidy also reads any .clang-tidy between a source file and
+            # electron/, so those go to the worker and into the cache key too.
+            "electron/shell:clang_tidy_configs",
         ],
         "exclude_input_patterns": ["*.stamp"],
         "remote": True,
@@ -141,9 +144,15 @@ def init(ctx):
       step_config["executables"].extend(linux_tools)
     step_config["rules"].insert(0, tidy_rule)
 
+    filegroups = dict(mod.filegroups)
+    filegroups["electron/shell:clang_tidy_configs"] = {
+        "type": "glob",
+        "includes": [".clang-tidy"],
+    }
+
     return module(
       "config",
       step_config = json.encode(step_config),
-      filegroups = mod.filegroups,
+      filegroups = filegroups,
       handlers = mod.handlers,
     )


### PR DESCRIPTION
clang-tidy reads every `.clang-tidy` between a source file and the tree root. The `electron/clang-tidy` rule from #896 only uploaded the two top-level configs, so a config added under `electron/shell` would apply locally but never reach the RBE worker, and it stayed out of the cache key. Raised by @dsanders11 on electron/electron#53447.

- Glob `electron/shell` for `.clang-tidy` files and add them to the rule's inputs.

Tested with a temporary `electron/shell/app/.clang-tidy` that enables `readability-identifier-length`, running the `command_line_args.cc` step with `-strict_remote`:

| rule | inputs | result |
|---|---|---|
| current (`main`) | 260 | passes; the nested config never reaches the worker |
| this PR | 261 | fails with `readability-identifier-length`, as it does locally |
| this PR, nested config removed | 260 | passes, cache hit on the same key as `main` |
